### PR TITLE
Make OpenBabel a soft dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ pip install aiidalab-widgets-base
 Install the corresponding `aiidalab-widgets-base` AiiDA lab application
 via the app manager as usual.
 
+### Optional dependencies
+
+* The `SmilesWidget` widget requires the [OpenBabel](http://openbabel.org/) library.
+
 ## Usage
 
 Using the widgets usually just involves importing and displaying them.

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -10,7 +10,7 @@ from traitlets import Bool
 import ipywidgets as ipw
 
 from aiida.orm import CalcFunctionNode, CalcJobNode, Node, QueryBuilder, WorkChainNode, StructureData
-from .utils import get_ase_from_file
+from .utils import get_ase_from_file, requires_open_babel
 
 
 class StructureManagerWidget(ipw.VBox):  # pylint: disable=too-many-instance-attributes
@@ -358,6 +358,7 @@ class SmilesWidget(ipw.VBox):
 
     SPINNER = """<i class="fa fa-spinner fa-pulse" style="color:red;" ></i>"""
 
+    @requires_open_babel
     def __init__(self):
         self.smiles = ipw.Text()
         self.create_structure_btn = ipw.Button(description="Generate molecule", button_style='info')
@@ -380,9 +381,10 @@ class SmilesWidget(ipw.VBox):
         asemol.center()
         return asemol
 
+    @requires_open_babel
     def _optimize_mol(self, mol):
         """Optimize a molecule using force field (needed for complex SMILES)."""
-        from openbabel import pybel
+        from openbabel import pybel  # pylint:disable=import-error
 
         self.output.value = "Screening possible conformers {}".format(self.SPINNER)  #font-size:20em;
 
@@ -400,10 +402,11 @@ class SmilesWidget(ipw.VBox):
         f_f.GetCoordinates(mol.OBMol)
         self.output.value = ""
 
+    @requires_open_babel
     def _on_button_pressed(self, change):  # pylint: disable=unused-argument
         """Convert SMILES to ase structure when button is pressed."""
         self.output.value = ""
-        from openbabel import pybel
+        from openbabel import pybel  # pylint:disable=import-error
         if not self.smiles.value:
             return
 

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -10,7 +10,7 @@ from traitlets import Bool
 import ipywidgets as ipw
 
 from aiida.orm import CalcFunctionNode, CalcJobNode, Node, QueryBuilder, WorkChainNode, StructureData
-from .utils import get_ase_from_file, requires_open_babel
+from .utils import get_ase_from_file
 
 
 class StructureManagerWidget(ipw.VBox):  # pylint: disable=too-many-instance-attributes
@@ -358,8 +358,15 @@ class SmilesWidget(ipw.VBox):
 
     SPINNER = """<i class="fa fa-spinner fa-pulse" style="color:red;" ></i>"""
 
-    @requires_open_babel
     def __init__(self):
+        try:
+            import openbabel  # pylint: disable=unused-import
+        except ImportError:
+            super().__init__(
+                [ipw.HTML("The SmilesWidget requires the OpenBabel library, "
+                          "but the library was not found.")])
+            return
+
         self.smiles = ipw.Text()
         self.create_structure_btn = ipw.Button(description="Generate molecule", button_style='info')
         self.create_structure_btn.on_click(self._on_button_pressed)
@@ -381,7 +388,6 @@ class SmilesWidget(ipw.VBox):
         asemol.center()
         return asemol
 
-    @requires_open_babel
     def _optimize_mol(self, mol):
         """Optimize a molecule using force field (needed for complex SMILES)."""
         from openbabel import pybel  # pylint:disable=import-error
@@ -402,7 +408,6 @@ class SmilesWidget(ipw.VBox):
         f_f.GetCoordinates(mol.OBMol)
         self.output.value = ""
 
-    @requires_open_babel
     def _on_button_pressed(self, change):  # pylint: disable=unused-argument
         """Convert SMILES to ase structure when button is pressed."""
         self.output.value = ""

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
-from functools import wraps
 
 
 def valid_arguments(arguments, valid_args):
@@ -43,23 +42,3 @@ def get_ase_from_file(fname):
     if len(traj) > 1:
         print(("Warning: Uploaded file {} contained more than one structure. I take the first one.".format(fname)))
     return traj[0]
-
-
-def requires_open_babel(wrapped):
-    """Decorator for functions that require the OpenBabel library.
-
-    Check for OpenBabel and raise ImportError with informative error message
-    in case that the library is not available.
-    """
-
-    @wraps(wrapped)
-    def inner(*args, **kwargs):
-        try:
-            import openbabel  # pylint: disable=unused-import
-        except ImportError:
-            raise ImportError("The '{}' function requires the OpenBabel library, "
-                              "but the library was not found.".format(wrapped))
-        else:
-            return wrapped(*args, **kwargs)
-
-    return inner

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from functools import wraps
 
 
 def valid_arguments(arguments, valid_args):
@@ -42,3 +43,23 @@ def get_ase_from_file(fname):
     if len(traj) > 1:
         print(("Warning: Uploaded file {} contained more than one structure. I take the first one.".format(fname)))
     return traj[0]
+
+
+def requires_open_babel(wrapped):
+    """Decorator for functions that require the OpenBabel library.
+
+    Check for OpenBabel and raise ImportError with informative error message
+    in case that the library is not available.
+    """
+
+    @wraps(wrapped)
+    def inner(*args, **kwargs):
+        try:
+            import openbabel  # pylint: disable=unused-import
+        except ImportError:
+            raise ImportError("The '{}' function requires the OpenBabel library, "
+                              "but the library was not found.".format(wrapped))
+        else:
+            return wrapped(*args, **kwargs)
+
+    return inner

--- a/structures.ipynb
+++ b/structures.ipynb
@@ -15,7 +15,7 @@
     "    (\"From computer\", StructureUploadWidget()),\n",
     "    (\"COD\", CodQueryWidget()),\n",
     "    (\"AiiDA database\", StructureBrowserWidget()),\n",
-    "    (\"SMILES\", SmilesWidget()),\n",
+    "#    (\"SMILES\", SmilesWidget()),  # requires OpenBabel! \n",
     "    (\"From Examples\", StructureExamplesWidget(\n",
     "        examples=[\n",
     "            (\"Silicon oxide\", \"miscellaneous/structures/SiO2.xyz\")\n",

--- a/structures.ipynb
+++ b/structures.ipynb
@@ -15,7 +15,7 @@
     "    (\"From computer\", StructureUploadWidget()),\n",
     "    (\"COD\", CodQueryWidget()),\n",
     "    (\"AiiDA database\", StructureBrowserWidget()),\n",
-    "#    (\"SMILES\", SmilesWidget()),  # requires OpenBabel! \n",
+    "    (\"SMILES\", SmilesWidget()),  # requires OpenBabel! \n",
     "    (\"From Examples\", StructureExamplesWidget(\n",
     "        examples=[\n",
     "            (\"Silicon oxide\", \"miscellaneous/structures/SiO2.xyz\")\n",


### PR DESCRIPTION
Explicitly declare dependency for functions that require it and raise
informative error message in case that the library is not available.