### PR TITLE
CalcJobOutputWidget bug fix.

### DIFF
--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -412,7 +412,7 @@ class CalcJobOutputWidget(ipw.Textarea):
 
         output_file_path = None
         try:
-            output_file_path = os.path.join(self.calculation.outputs.remote_folders.get_remote_path(),
+            output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
                                             self.calculation.attributes['output_filename'])
         except KeyError:
             self.placeholder = "The `output_filename` attribute is not set for " \

--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -416,8 +416,8 @@ class CalcJobOutputWidget(ipw.Textarea):
                 output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
                                                 self.calculation.attributes['output_filename'])
             except KeyError:
-                self.placeholder = f"The `output_filename` attribute isn't set for {self.calculation.process_class}. " \
-                "The output won't appear here."
+                self.placeholder = f"The `output_filename` attribute is not set for {self.calculation.process_class}. " \
+                "Nothing to show."
         if output_file_path and os.path.exists(output_file_path):
             with open(output_file_path) as fobj:
                 difference = fobj.readlines()[len(self.output):-1]  # Only adding the difference

--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -412,8 +412,12 @@ class CalcJobOutputWidget(ipw.Textarea):
 
         output_file_path = None
         if 'remote_folder' in self.calculation.outputs:
-            output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
-                                            self.calculation.attributes['output_filename'])
+            try:
+                output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
+                                                self.calculation.attributes['output_filename'])
+            except KeyError:
+                self.placeholder = f"The `output_filename` attribute isn't set for {self.calculation.process_class}. " \
+                "The output won't appear here."
         if output_file_path and os.path.exists(output_file_path):
             with open(output_file_path) as fobj:
                 difference = fobj.readlines()[len(self.output):-1]  # Only adding the difference

--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -410,7 +410,6 @@ class CalcJobOutputWidget(ipw.Textarea):
         if self.calculation is None:
             return
 
-        output_file_path = None
         try:
             output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
                                             self.calculation.attributes['output_filename'])
@@ -420,12 +419,12 @@ class CalcJobOutputWidget(ipw.Textarea):
         except NotExistentAttributeError:
             self.placeholder = "The object `remote_folder` was not found among the process outputs. " \
             "Nothing to show."
-
-        if output_file_path and os.path.exists(output_file_path):
-            with open(output_file_path) as fobj:
-                difference = fobj.readlines()[len(self.output):-1]  # Only adding the difference
-                self.output += difference
-                self.value += ''.join(difference)
+        else:
+            if os.path.exists(output_file_path):
+                with open(output_file_path) as fobj:
+                    difference = fobj.readlines()[len(self.output):-1]  # Only adding the difference
+                    self.output += difference
+                    self.value += ''.join(difference)
 
         # Auto scroll down. Doesn't work in detached mode.
         # Also a hack as it is applied to all the textareas

--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -416,8 +416,8 @@ class CalcJobOutputWidget(ipw.Textarea):
                 output_file_path = os.path.join(self.calculation.outputs.remote_folder.get_remote_path(),
                                                 self.calculation.attributes['output_filename'])
             except KeyError:
-                self.placeholder = f"The `output_filename` attribute is not set for {self.calculation.process_class}. " \
-                "Nothing to show."
+                self.placeholder = "The `output_filename` attribute is not set for " \
+                f"{self.calculation.process_class}. Nothing to show."
         if output_file_path and os.path.exists(output_file_path):
             with open(output_file_path) as fobj:
                 difference = fobj.readlines()[len(self.output):-1]  # Only adding the difference


### PR DESCRIPTION
fixes #104 

Gracefully handle situations where `output_filename` attribute isn't
set for a calculation class.