### PR TITLE
Extend embedded also to OptimadeQueryFilterWidget

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -141,7 +141,7 @@ class OptimadeQueryWidget(ipw.VBox):
             **kwargs,
     ) -> None:
         providers = OptimadeQueryProviderWidget(embedded=embedded)
-        filters = OptimadeQueryFilterWidget()
+        filters = OptimadeQueryFilterWidget(embedded=embedded)
 
         ipw.dlink((providers, 'database'), (filters, 'database'))
 

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -122,6 +122,9 @@ class OptimadeQueryWidget(ipw.VBox):
     :class:`aiidalab_widgets_base.structures.StructureManagerWidget`,
     embedded into applications.
 
+    NOTE: `embedded` for `OptimadeQueryFilterWidget` was introduced in `optimade-client`
+    version 2020.11.5.
+
     :param embedded: Whether or not to show extra database and provider information.
         When set to `True`, the extra information will be hidden, this is useful
         in situations where the widget is used in a Tab or similar, e.g., for the


### PR DESCRIPTION
The `embedded` parameter is now part of `OptimadeQueryFilterWidget` as well, and this change will ensure the `OptimadeQueryWidget` extends the `embedded` parameter also to this sub-widget.

Note, this will not be valid until CasperWA/voila-optimade-client#203 has been merged and a new version of `optimade-client` is released.