### PR TITLE
Remove scikit-learn as a dependancy

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,8 +16,7 @@
             "nglview",
             "numpy",
             "optimade-client",
-            "pandas",
-            "scikit-learn"
+            "pandas"
         ]
     }
 }

--- a/setup.json
+++ b/setup.json
@@ -20,8 +20,7 @@
         "nglview",
         "numpy",
         "optimade-client",
-        "pandas",
-        "scikit-learn"
+        "pandas"
     ],
     "extras_require": {
         "docs": [

--- a/setup.json
+++ b/setup.json
@@ -23,6 +23,10 @@
         "pandas"
     ],
     "extras_require": {
+        "smiles": [
+            "openbabel",
+            "rdkit"
+        ],
         "docs": [
             "sphinx",
             "sphinx-rtd-theme",


### PR DESCRIPTION
In the last commit 1abe24b @cpignedoli removed the only import of sklearn, so I don't think this is any longer a dependency