### PR TITLE
added copy atoms

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -835,7 +835,9 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
         link((use_covalent_radius, "value"), (self.bond_length, "disabled"))
 
         # Copy atoms
-        btn_copy_sel = ipw.Button(description='Copy selected', layout={'width': 'initial'})
+        btn_copy_sel = ipw.Button(
+            description="Copy selected", layout={"width": "initial"}
+        )
         btn_copy_sel.on_click(self.copy_sel)
 
         # Modify atom.
@@ -898,8 +900,7 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
                 ipw.HTML(
                     "<b>Modify atom(s):</v>", layout={"margin": "20px 0px 10px 0px"}
                 ),
-            ipw.HTML("<b>Modify atom(s):</v>", layout={'margin': '20px 0px 10px 0px'}),
-                ipw.HBox([btn_copy_sel], layout={'margin': '0px 0px 0px 20px'}),
+                ipw.HBox([btn_copy_sel], layout={"margin": "0px 0px 0px 20px"}),
                 ipw.HBox(
                     [self.element, self.ligand], layout={"margin": "0px 0px 0px 20px"}
                 ),
@@ -1061,7 +1062,7 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
         last_atom = atoms.get_global_number_of_atoms()
         selection = self.selection
 
-        #The action
+        # The action
         add_atoms = atoms[self.selection].copy()
         add_atoms.translate([0.5, 0, 0])
         atoms += add_atoms

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -1057,14 +1057,14 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
         self.selection = selection
 
     def copy_sel(self, _=None):
-        """Copy selected atoms and shift by 0.5A in x"""
+        """Copy selected atoms and shift by 1.0 A along X-axis."""
         atoms = self.structure.copy()
         last_atom = atoms.get_global_number_of_atoms()
         selection = self.selection
 
         # The action
         add_atoms = atoms[self.selection].copy()
-        add_atoms.translate([0.5, 0, 0])
+        add_atoms.translate([1.0, 0, 0])
         atoms += add_atoms
 
         self.structure = atoms

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -834,6 +834,10 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
         )
         link((use_covalent_radius, "value"), (self.bond_length, "disabled"))
 
+        # Copy atoms
+        btn_copy_sel = ipw.Button(description='Copy selected', layout={'width': 'initial'})
+        btn_copy_sel.on_click(self.copy_sel)
+
         # Modify atom.
         btn_modify = ipw.Button(
             description="Modify selected",
@@ -894,6 +898,8 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
                 ipw.HTML(
                     "<b>Modify atom(s):</v>", layout={"margin": "20px 0px 10px 0px"}
                 ),
+            ipw.HTML("<b>Modify atom(s):</v>", layout={'margin': '20px 0px 10px 0px'}),
+                ipw.HBox([btn_copy_sel], layout={'margin': '0px 0px 0px 20px'}),
                 ipw.HBox(
                     [self.element, self.ligand], layout={"margin": "0px 0px 0px 20px"}
                 ),
@@ -1048,6 +1054,20 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
 
         self.structure = atoms
         self.selection = selection
+
+    def copy_sel(self, _=None):
+        """Copy selected atoms and shift by 0.5A in x"""
+        atoms = self.structure.copy()
+        last_atom = atoms.get_global_number_of_atoms()
+        selection = self.selection
+
+        #The action
+        add_atoms = atoms[self.selection].copy()
+        add_atoms.translate([0.5, 0, 0])
+        atoms += add_atoms
+
+        self.structure = atoms
+        self.selection = [i for i in range(last_atom, last_atom + len(selection))]
 
     def add(self, _=None):
         """Add atoms."""

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -823,7 +823,8 @@ class StructureDataViewer(_StructureDataBaseViewer):
             info += add_info(self.selection[0], self.structure[self.selection[0]])
             info += add_info(self.selection[1], self.structure[self.selection[1]])
             dist = self.structure.get_distance(*self.selection)
-            info += f"Distance: {dist:.2f}<br>Geometric center: ({geom_center})"
+            distv = self.structure.get_distance(*self.selection, vector=True)
+            info += f"Distance: {dist:.2f} ({print_pos(distv)})<br>Geometric center: ({geom_center})"
             return info
 
         info_natoms_geo_center = (


### PR DESCRIPTION
a selection of atoms can be copied and will appear shifted by 0.5A in x (same convention as some commercial editors)
selection will be set to the newly added atoms so that they can be easily identified and moved