### PR TITLE
Add AiidaNodeViewWidget class.

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -34,12 +34,13 @@ from .structures import (
     StructureManagerWidget,
     StructureUploadWidget,
 )
-from .viewers import AiidaNodeViewWidget, register_viewer_widget, viewer  # noqa
+from .viewers import AiidaNodeViewWidget, register_viewer_widget, viewer
 from .wizard import WizardAppWidget, WizardAppWidgetStep
 
 __all__ = [
     "AiiDACodeSetup",
     "AiidaComputerSetup",
+    "AiidaNodeViewWidget",
     "BasicStructureEditor",
     "CodQueryWidget",
     "CodeDatabaseWidget",

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -34,7 +34,7 @@ from .structures import (
     StructureManagerWidget,
     StructureUploadWidget,
 )
-from .viewers import register_viewer_widget, viewer
+from .viewers import AiidaNodeViewWidget, register_viewer_widget, viewer  # noqa
 from .wizard import WizardAppWidget, WizardAppWidgetStep
 
 __all__ = [

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -8,9 +8,10 @@ from copy import deepcopy
 import ipywidgets as ipw
 import nglview
 import numpy as np
+import traitlets
 from aiida.orm import Node
 from ase import Atoms, neighborlist
-from IPython.display import display
+from IPython.display import clear_output, display
 from matplotlib.colors import to_rgb
 from numpy.linalg import norm
 from traitlets import (
@@ -77,6 +78,29 @@ def viewer(obj, downloadable=True, **kwargs):
             )
             return obj
         raise exc
+
+
+class DisplayAiidaObject(ipw.VBox):
+    node = traitlets.Instance(Node, allow_none=True)
+
+    def __init__(self, **kwargs):
+        self._output = ipw.Output()
+        super().__init__(
+            children=[
+                self._output,
+            ],
+            **kwargs,
+        )
+
+    @traitlets.observe("node")
+    def _observe_node(self, change):
+        from aiidalab_widgets_base import viewer
+
+        if change["new"] != change["old"]:
+            with self._output:
+                clear_output()
+                if change["new"]:
+                    display(viewer(change["new"]))
 
 
 @register_viewer_widget("data.dict.Dict.")

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -80,7 +80,7 @@ def viewer(obj, downloadable=True, **kwargs):
         raise exc
 
 
-class DisplayAiidaObject(ipw.VBox):
+class AiidaNodeViewWidget(ipw.VBox):
     node = traitlets.Instance(Node, allow_none=True)
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Convenience class that can always be displayed with the `display` function.
Unlike viewer, `DisplayAiidaObject` always has a `node` trait that can be provided
later. Once the node is provided, the `DisplayAiidaObject` object will automatically
show it.

(extracted from #181)