### PR TITLE
StructureManagerWidget: connect structure_node trait to the viewer.

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -92,7 +92,7 @@ class StructureManagerWidget(ipw.VBox):
             self.viewer = viewer
         else:
             self.viewer = StructureDataViewer(downloadable=False)
-        dlink((self, "structure"), (self.viewer, "structure"))
+        dlink((self, "structure_node"), (self.viewer, "structure"))
 
         # Store button.
         self.btn_store = ipw.Button(description="Store in AiiDA", disabled=True)


### PR DESCRIPTION
Previously, it was structure trait that was connected to a viewer.
However, structure trait is not an AiiDA node, therefore it does
not contain the provenance information.