### PR TITLE
fix: dependency conflicts

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ install_requires =
     pandas~=1.0
     scikit-learn~=0.24
     vapory~=0.1.2
+    jupyter-client<7
+    nbconvert<6
 python_requires = >=3.7
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
fix #228 

New releases of jupyter-client and nbconvert had conflicting
dependencies:

jupyter-client 7.0.2 requires nest-asyncio>=1.5, but you'll have nest-asyncio 1.4.3 which is incompatible.
nbconvert 6.1.0 requires traitlets>=5.0, but you'll have traitlets 4.3.3 which is incompatible.

The first one conflicts with plumpy, the second conflicts with the
aiidalab package.

Until these are fixed, we limit the versions of jupyter-client and
nbconvert.