### PR TITLE
Node tree namespace

### DIFF
--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -107,17 +107,6 @@ class AiidaOutputsTreeNode(TreeNode):
         super().__init__(name=name, **kwargs)
 
 
-class AiidaNamespaceTreeNode(TreeNode):
-    icon = traitlets.Unicode("folder").tag(sync=True)
-    disabled = traitlets.Bool(True).tag(sync=True)
-
-    def __init__(self, name, parent_pk, namespace=None, **kwargs):
-        self.parent_pk = parent_pk
-        self.nodes_registry = dict()
-        self.namespace = namespace
-        super().__init__(name=name, **kwargs)
-
-
 class UnknownTypeTreeNode(AiidaNodeTreeNode):
     icon = traitlets.Unicode("file").tag(sync=True)
 

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -226,28 +226,23 @@ class NodesTreeWidget(ipw.Output):
         else:
             outputs = process_node.outputs
 
-        output_nodes = {
-            key: outputs[key]
-            for key in outputs
-            if not isinstance(outputs[key], AttributeDict)
-        }
-        for key in sorted(output_nodes.keys(), key=lambda k: output_nodes[k].pk):
-            node = output_nodes[key]
-            if node.pk not in root.nodes_registry:
-                root.nodes_registry[node.pk] = cls._to_tree_node(
-                    node, name=f"{key}<{node.pk}>"
-                )
-            yield root.nodes_registry[node.pk]
+        output_nodes = {key: outputs[key] for key in outputs}
 
-        output_attributs = {
-            key: outputs[key]
-            for key in outputs
-            if isinstance(outputs[key], AttributeDict)
-        }
-        for key in output_attributs.keys():
-            yield AiidaOutputsTreeNode(
-                name=key, parent_pk=root.parent_pk, namespace=key
-            )
+        for key in sorted(
+            output_nodes.keys(), key=lambda k: getattr(outputs[k], "pk", -1)
+        ):
+            node = output_nodes[key]
+
+            if isinstance(node, AttributeDict):
+                yield AiidaOutputsTreeNode(
+                    name=key, parent_pk=root.parent_pk, namespace=key
+                )
+            else:
+                if node.pk not in root.nodes_registry:
+                    root.nodes_registry[node.pk] = cls._to_tree_node(
+                        node, name=f"{key}<{node.pk}>"
+                    )
+                yield root.nodes_registry[node.pk]
 
     @classmethod
     def _find_children(cls, root):

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -2,8 +2,8 @@
 import ipywidgets as ipw
 import traitlets
 from aiida.cmdline.utils.ascii_vis import calc_info
-from aiida.engine import ProcessState
 from aiida.common import AttributeDict
+from aiida.engine import ProcessState
 from aiida.orm import (
     CalcFunctionNode,
     CalcJobNode,
@@ -100,11 +100,13 @@ class AiidaOutputsTreeNode(TreeNode):
     icon = traitlets.Unicode("folder").tag(sync=True)
     disabled = traitlets.Bool(True).tag(sync=True)
 
-    def __init__(self, name, parent_pk, **kwargs):
+    def __init__(self, name, parent_pk, namespace=None, **kwargs):
         self.parent_pk = parent_pk
         self.nodes_registry = dict()
+        self.namespace = namespace
         super().__init__(name=name, **kwargs)
-        
+
+
 class AiidaNamespaceTreeNode(TreeNode):
     icon = traitlets.Unicode("folder").tag(sync=True)
     disabled = traitlets.Bool(True).tag(sync=True)
@@ -219,29 +221,34 @@ class NodesTreeWidget(ipw.Output):
     @classmethod
     def _find_outputs(cls, root):
         process_node = load_node(root.parent_pk)
-        if isinstance(root, AiidaNamespaceTreeNode):
+        if root.namespace:
             outputs = process_node.outputs[root.namespace]
         else:
             outputs = process_node.outputs
-            
-        outputs = {key: outputs[key] for key in outputs if not isinstance(outputs[key], AttributeDict)}
-        for key in sorted(outputs.keys(), key=lambda k: outputs[k].pk):
-            output_node = outputs[key]
-            if output_node.pk not in root.nodes_registry:
-                root.nodes_registry[output_node.pk] = cls._to_tree_node(
-                    output_node, name=f"{key}<{output_node.pk}>"
-                )
-            yield root.nodes_registry[output_node.pk]
 
-    @classmethod
-    def _find_namespace(cls, root):
-        """find namespace from a output node"""
-        process_node = load_node(root.parent_pk)
-        outputs = {k: process_node.outputs[k] for k in process_node.outputs}
-        for key in outputs.keys():
-            if isinstance(outputs[key], AttributeDict):
-                yield AiidaNamespaceTreeNode(name=key, parent_pk=root.parent_pk, namespace=key)
-                
+        output_nodes = {
+            key: outputs[key]
+            for key in outputs
+            if not isinstance(outputs[key], AttributeDict)
+        }
+        for key in sorted(output_nodes.keys(), key=lambda k: output_nodes[k].pk):
+            node = output_nodes[key]
+            if node.pk not in root.nodes_registry:
+                root.nodes_registry[node.pk] = cls._to_tree_node(
+                    node, name=f"{key}<{node.pk}>"
+                )
+            yield root.nodes_registry[node.pk]
+
+        output_attributs = {
+            key: outputs[key]
+            for key in outputs
+            if isinstance(outputs[key], AttributeDict)
+        }
+        for key in output_attributs.keys():
+            yield AiidaOutputsTreeNode(
+                name=key, parent_pk=root.parent_pk, namespace=key
+            )
+
     @classmethod
     def _find_children(cls, root):
         """Find all children of the provided AiiDA node."""
@@ -249,9 +256,6 @@ class NodesTreeWidget(ipw.Output):
             yield root.outputs_node
             yield from cls._find_called(root)
         elif isinstance(root, AiidaOutputsTreeNode):
-            yield from cls._find_namespace(root)
-            yield from cls._find_outputs(root)
-        elif isinstance(root, AiidaNamespaceTreeNode):
             yield from cls._find_outputs(root)
 
     @classmethod


### PR DESCRIPTION
fixes https://github.com/aiidalab/aiidalab-widgets-base/issues/262

Here I check the namespace in the output and make a `TreeNode` for it. I modified `AiidaOutputsTreeNode` by adding an attribute `self.namespace` to store the current namespace level.
Since the namespace and output have the same structure, that is to say, the output can be regarded as a special namespace in the top hierarchy without the property `namespace` being set (`nampspace=None`).

However, the namespace can also be nested where I didn't consider this but will be easy to add along with this PR. I suggest we keep one level nest namespace as this PR for the moment and get it merged, elaborate to a more comprehensive situation when we encounter the issue. 