### PR TITLE
Make StructureDataViewer more configurable

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -92,7 +92,7 @@ class StructureManagerWidget(ipw.VBox):
         if viewer:
             self.viewer = viewer
         else:
-            self.viewer = StructureDataViewer(downloadable=False)
+            self.viewer = StructureDataViewer(**kwargs)
         dlink((self, "structure_node"), (self.viewer, "structure"))
 
         # Store button.

--- a/notebooks/aiida_datatypes_viewers.ipynb
+++ b/notebooks/aiida_datatypes_viewers.ipynb
@@ -69,7 +69,7 @@
    "source": [
     "CifData = DataFactory('cif')\n",
     "s = CifData(ase=m)\n",
-    "vwr = viewer(s.store(), downloadable=True)\n",
+    "vwr = viewer(s.store(), configuration_tabs=['Selection', 'Appearance', 'Cell', 'Download'])\n",
     "display(vwr)"
    ]
   },
@@ -88,7 +88,7 @@
    "source": [
     "StructureData = DataFactory('structure')\n",
     "s = StructureData(ase=m)\n",
-    "vwr = viewer(s.store(), downloadable=True)\n",
+    "vwr = viewer(s.store())\n",
     "display(vwr)"
    ]
   },


### PR DESCRIPTION
 - Fix configure_view=False option, only register observers
   when tabs are shown.
 - select which configuration tabs to display.
 - camera_default option
 - option to hide camera selection

Closes #284. Fixes #283. See these issues for more details/reasoning.