### PR TITLE
SmilesWidget: PBC=False + better error handling

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -764,9 +764,7 @@ class SmilesWidget(ipw.VBox):
 
         if not self.smiles.value:
             return
-        spiner = "Screening possible conformers {}".format(
-            self.SPINNER
-        )  # font-size:20em;
+        spiner = f"Screening possible conformers {self.SPINNER}"  # font-size:20em;
         self.output.value = spiner
         self.structure = self._mol_from_smiles(self.smiles.value)
         # Don't overwrite possible error/warning messages

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -665,7 +665,12 @@ class SmilesWidget(ipw.VBox):
         """Create ase Atoms object."""
         # Get the principal axes and realign the molecule along z-axis.
         positions = PCA(n_components=3).fit_transform(positions)
-        atoms = Atoms(species, positions=positions, pbc=True)
+        try:
+            atoms = Atoms(species, positions=positions, pbc=False)
+        except KeyError:
+            # https://github.com/aiidalab/aiidalab-widgets-base/issues/270
+            self.output.value = "ERROR: Invalid atom name"
+            return None
         atoms.cell = np.ptp(atoms.positions, axis=0) + 10
         atoms.center()
         # We're attaching this info so that it
@@ -705,9 +710,18 @@ class SmilesWidget(ipw.VBox):
 
         smiles = smiles.replace("[", "").replace("]", "")
         mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            # Something is seriously wrong with the SMILES code,
+            # just return None and don't attempt anything else.
+            self.output.value = "ERROR: Invalid SMILES string"
+            return None
         mol = Chem.AddHs(mol)
 
         AllChem.EmbedMolecule(mol, maxAttempts=20, randomSeed=42)
+        if not AllChem.UFFHasAllMoleculeParams(mol):
+            msg = "WARNING: Missing UFF parameters"
+            raise ValueError(msg)
+
         AllChem.UFFOptimizeMolecule(mol, maxIters=steps)
         positions = mol.GetConformer().GetPositions()
         natoms = mol.GetNumAtoms()
@@ -718,7 +732,8 @@ class SmilesWidget(ipw.VBox):
         """Convert SMILES to ase structure try rdkit then pybel"""
         try:
             return self._rdkit_opt(smiles, steps)
-        except ValueError:
+        except ValueError as e:
+            self.output.value = str(e)
             return self._pybel_opt(smiles, steps)
 
     def _on_button_pressed(self, change):  # pylint: disable=unused-argument
@@ -727,11 +742,14 @@ class SmilesWidget(ipw.VBox):
 
         if not self.smiles.value:
             return
-        self.output.value = "Screening possible conformers {}".format(
+        spiner = "Screening possible conformers {}".format(
             self.SPINNER
         )  # font-size:20em;
+        self.output.value = spiner
         self.structure = self._mol_from_smiles(self.smiles.value)
-        self.output.value = ""
+        # Don't overwrite possible error/warning messages
+        if self.output.value == spiner:
+            self.output.value = ""
 
     @default("structure")
     def _default_structure(self):


### PR DESCRIPTION
 - Make PBC=False by default, closes #289
 - Improve handling of invalid SMILES input, closes #270.

Turns out that the RDkit library doesn't have a very good error handling, they just print all errors and warnings to stderr.
I tried to improve things on our side to capture obviously errorneous SMILES input and print a generic error message.
We could improve this further by capturing stderr and displaying the original RDKit messages as per http://rdkit.blogspot.com/2016/03/capturing-error-information.html, but not sure it's worth it the additional code complexity and messing with stderr.

**Some examples with invalid SMILES:**

1. 
input1: `c1cc1`
stderr: `RDKit ERROR: [19:58:16] Can't kekulize mol.  Unkekulized atoms: 0 1 2` 
input2: `Ch`
stderr: `RDKit ERROR: [20:01:52] SMILES Parse Error: syntax error while parsing: Ch
RDKit ERROR: [20:01:52] SMILES Parse Error: Failed parsing SMILES 'Ch' for input: 'Ch'`

Both of these would result in:
```
ArgumentError: Python argument types in
    rdkit.Chem.rdmolops.AddHs(NoneType)
did not match C++ signature:
    AddHs(RDKit::ROMol mol, bool explicitOnly=False, bool addCoords=False, boost::python::api::object onlyOnAtoms=None, bool addResidueInfo=False)
```
With this PR, we just print "ERROR: Invalid SMILES code"

---
2.
input: `CC(C)(C)*OO`
For some reason, this one passes through rdkit even though it contains an invalid character `*`, and fails later in ASE, as described in #270. In this PR, we print "Invalid atom type".

---
3. 
input: `CS(C)(C)=O`
This is actually a valid SMILES string, as discussed in https://github.com/rdkit/rdkit/issues/200. However, the UFF force field that we use for minimization is missing parameters for sulphur in this particular hybridization, so the rdkit minimization fails with
```
~/apps/aiidalab-widgets-base/aiidalab_widgets_base/structures.py in _rdkit_opt(self, smiles, steps)
    706 
    707         AllChem.EmbedMolecule(mol, maxAttempts=20, randomSeed=42)
--> 708         AllChem.UFFOptimizeMolecule(mol, maxIters=steps)
    709         positions = mol.GetConformer().GetPositions()
    710         natoms = mol.GetNumAtoms()

RuntimeError: Pre-condition Violation
	bad params pointer
	Violation occurred on line 75 in file Code/ForceField/UFF/AngleBend.cpp
	Failed Expression: at2Params
	RDKIT: 2020.09.1
	BOOST: 1_74
```
With the new code, we abandon rdkit if we detect missing UFF parameters, and instead try OpenBabel instead, which in this case actually produces the desired molecule.

@cpignedoli would you mind taking a look as the original author of the widget. I just want to make sure that I didn't break some use case that worked before. I would be also interested to hear a bit about the original design / testing of the current code, i.e. for which SMILES did you find OpenBabel working better than RDKit? Thanks!
