### PR TITLE
Remove arguments from all the remaining `.super()` calls.

### DIFF
--- a/aiidalab_widgets_base/codes.py
+++ b/aiidalab_widgets_base/codes.py
@@ -254,7 +254,7 @@ class AiiDACodeSetup(ipw.VBox):
             btn_setup_code,
             self._setup_code_out,
         ]
-        super(AiiDACodeSetup, self).__init__(children, **kwargs)
+        super().__init__(children, **kwargs)
 
     @validate("input_plugin")
     def _validate_input_plugin(self, proposal):

--- a/aiidalab_widgets_base/computers.py
+++ b/aiidalab_widgets_base/computers.py
@@ -171,7 +171,7 @@ class SshComputerSetup(ipw.VBox):
             btn_setup_ssh,
             self._setup_ssh_out,
         ]
-        super(SshComputerSetup, self).__init__(children, **kwargs)
+        super().__init__(children, **kwargs)
 
     @staticmethod
     def _ssh_keygen():
@@ -736,7 +736,7 @@ class AiidaComputerSetup(ipw.VBox):
             ipw.HBox([btn_setup_comp, btn_test]),
             ipw.HBox([self._setup_comp_out, self._test_out]),
         ]
-        super(AiidaComputerSetup, self).__init__(children, **kwargs)
+        super().__init__(children, **kwargs)
 
     def _configure_computer(self):
         """Create AuthInfo."""

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -66,7 +66,7 @@ class CodQueryWidget(ipw.VBox):
             self.query_message,
             ipw.HBox([self.drop_structure, self.link]),
         ]
-        super(CodQueryWidget, self).__init__(children=children, **kwargs)
+        super().__init__(children=children, **kwargs)
 
     @staticmethod
     def _query(idn=None, formula=None):

--- a/aiidalab_widgets_base/export.py
+++ b/aiidalab_widgets_base/export.py
@@ -15,7 +15,7 @@ class ExportButtonWidget(Button):
         if "layout" not in kwargs:
             kwargs["layout"] = {}
         kwargs["layout"]["width"] = "initial"
-        super(ExportButtonWidget, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.on_click(self.export_aiida_subgraph)
 
     def export_aiida_subgraph(self, change=None):  # pylint: disable=unused-argument


### PR DESCRIPTION
Otherwise, the objects fail to initialise.