### PR TITLE
Dependencies: Constrain Markupsafe version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ dev =
     bumpver==2021.1114
     pre-commit==2.10.1
 docs =
+    MarkupSafe<2.1
     myst-nb
     pydata-sphinx-theme
     sphinx


### PR DESCRIPTION
To workaround incompatibility (https://github.com/pallets/jinja/issues/1587).