### PR TITLE
NodesTreeWidget: _find_outputs parse nested namespace outputs

### DIFF
--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -216,15 +216,14 @@ class NodesTreeWidget(ipw.Output):
     def _find_outputs(cls, root):
         process_node = load_node(root.parent_pk)
 
-        outputs = process_node.outputs
-        # if output tree node is from namespace node
-        namespaces = root.namespaces
-        if namespaces:
-            outputs = functools.reduce(
-                lambda d, namespace: d[namespace], namespaces, process_node.outputs
-            )
+        # Gather outputs from node and its namespaces (if present):
+        outputs = functools.reduce(
+            lambda d, namespace: d[namespace],
+            root.namespaces or [],
+            process_node.outputs,
+        )
 
-        # convert aiida LinkManager to type dict
+        # Convert aiida.orm.LinkManager to dict
         output_nodes = {key: outputs[key] for key in outputs}
 
         for key in sorted(
@@ -236,7 +235,7 @@ class NodesTreeWidget(ipw.Output):
                 yield AiidaOutputsTreeNode(
                     name=key,
                     parent_pk=root.parent_pk,
-                    namespaces=(*namespaces, key),
+                    namespaces=(*root.namespaces, key),
                 )
 
             else:

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -215,10 +215,11 @@ class NodesTreeWidget(ipw.Output):
     @classmethod
     def _find_outputs(cls, root):
         """
-        A generator for all namespace and output nodes from the output root.
-        If a namespace encountered it generate a AiidaOutputsTreeNode with
-        the namespaces path stored so it can be accessed by root node and namespaces tuple
-        in walk tree breadth-first search.
+        A generator for all (including nested) output nodes.
+        
+        Generates an AiidaOutputsTreeNode when encountering a namespace,
+        keeping track of the full namespace path to make it accessible via the
+        root node in form of a breadth-first search.
         """
         process_node = load_node(root.parent_pk)
 

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -214,16 +214,22 @@ class NodesTreeWidget(ipw.Output):
 
     @classmethod
     def _find_outputs(cls, root):
+        """
+        A generator for all namespace and output nodes from the output root.
+        If a namespace encountered it generate a AiidaOutputsTreeNode with
+        the namespaces path stored so it can be accessed by root node and namespaces tuple
+        in walk tree breadth-first search.
+        """
         process_node = load_node(root.parent_pk)
 
-        # Gather outputs from node and its namespaces (if present):
+        # Gather outputs from node and its namespaces:
         outputs = functools.reduce(
-            lambda d, namespace: d[namespace],
+            lambda attr_dict, namespace: attr_dict[namespace],
             root.namespaces or [],
             process_node.outputs,
         )
 
-        # Convert aiida.orm.LinkManager to dict
+        # Convert aiida.orm.LinkManager or AttributDict (if namespace presented) to dict
         output_nodes = {key: outputs[key] for key in outputs}
 
         for key in sorted(
@@ -235,7 +241,7 @@ class NodesTreeWidget(ipw.Output):
                 yield AiidaOutputsTreeNode(
                     name=key,
                     parent_pk=root.parent_pk,
-                    namespaces=(*root.namespaces, key),
+                    namespaces=(*root.namespaces, key),  # attach nested namespace name
                 )
 
             else:

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -216,7 +216,7 @@ class NodesTreeWidget(ipw.Output):
     def _find_outputs(cls, root):
         """
         A generator for all (including nested) output nodes.
-        
+
         Generates an AiidaOutputsTreeNode when encountering a namespace,
         keeping track of the full namespace path to make it accessible via the
         root node in form of a breadth-first search.


### PR DESCRIPTION
fix #262

Previous PR #269 only works when the outputs have a single layer of
the nested namespace. We store the `parent_pk` in order to transversal nodes
level by level, however only with extra stored namespace parameter is not enough to access the
outputs in deep level. To solve this, `namespace` replace by `namespaces` which is a 
tuple to store the full path so that all the output nodes can be visited.