### PR TITLE
ComputationalResourcesWidget refresh things after every update

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -143,9 +143,8 @@ class ComputationalResourcesWidget(ipw.VBox):
         with self.hold_trait_notifications():
             success = self.ssh_computer_setup.on_setup_ssh()
             if success:
-                success = self.aiida_computer_setup.on_setup_computer()
-            if success:
-                self.aiida_code_setup.on_setup_code()
+                if self.aiida_computer_setup.on_setup_computer():
+                    self.aiida_code_setup.on_setup_code()
 
     def _get_codes(self):
         """Query the list of available codes."""

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -265,7 +265,7 @@ class SshComputerSetup(ipw.VBox):
         SshConnectionState, allow_none=True, default_value=None
     )
     SSH_POSSIBLE_RESPONSES = [
-        # order matters! the index will return by pexpect and compare 
+        # order matters! the index will return by pexpect and compare
         # with SshConnectionState
         "[Pp]assword:",  # 0
         "Now try logging into",  # 1

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -265,7 +265,7 @@ class SshComputerSetup(ipw.VBox):
         SshConnectionState, allow_none=True, default_value=None
     )
     SSH_POSSIBLE_RESPONSES = [
-        # order matters! the index will return by pexpect and compare
+        # order matters! the index will return by pexpect and compare 
         # with SshConnectionState
         "[Pp]assword:",  # 0
         "Now try logging into",  # 1
@@ -546,8 +546,6 @@ class SshComputerSetup(ipw.VBox):
         elif self.ssh_connection_state is SshConnectionState.do_you_want_to_continue:
             self._ssh_connection_process.sendline("yes")
 
-        self.ssh_connection_state = SshConnectionState.waiting_for_input
-
     def _handle_ssh_password(self):
         """Send a password to a remote computer."""
         message = (
@@ -565,6 +563,8 @@ class SshComputerSetup(ipw.VBox):
             self._ssh_password.disabled = False
             self._continue_with_password_button.disabled = False
             self._ssh_connection_message = message
+
+        self.ssh_connection_state = SshConnectionState.waiting_for_input
 
     def _on_verification_mode_change(self, change):
         """which verification mode is chosen."""

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -141,8 +141,7 @@ class ComputationalResourcesWidget(ipw.VBox):
     def quick_setup(self, _=None):
         """Go through all the setup steps automatically."""
         with self.hold_trait_notifications():
-            success = self.ssh_computer_setup.on_setup_ssh()
-            if success:
+            if self.ssh_computer_setup.on_setup_ssh():
                 if self.aiida_computer_setup.on_setup_computer():
                     self.aiida_code_setup.on_setup_code()
 

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -99,11 +99,11 @@ class ComputationalResourcesWidget(ipw.VBox):
             (self.comp_resources_database, "code_setup"),
             (self.aiida_code_setup, "code_setup"),
         )
-        self.aiida_code_setup.on_setup_code_success.append(self.refresh)
+        self.aiida_code_setup.on_setup_code_success(self.refresh)
 
         # After a successfull computer setup the codes widget should be refreshed.
         # E.g. the list of available computers needs to be updated.
-        self.aiida_computer_setup.on_setup_computer_success.append(
+        self.aiida_computer_setup.on_setup_computer_success(
             self.aiida_code_setup.refresh
         )
 
@@ -565,7 +565,7 @@ class AiidaComputerSetup(ipw.VBox):
 
     def __init__(self, **kwargs):
 
-        self.on_setup_computer_success = []
+        self._on_setup_computer_success = []
 
         # List of widgets to be displayed.
         self.label = ipw.Text(
@@ -742,7 +742,7 @@ class AiidaComputerSetup(ipw.VBox):
             try:
                 computer = orm.Computer.objects.get(label=self.label.value)
                 print(f"A computer called {self.label.value} already exists.")
-                for function in self.on_setup_computer_success:
+                for function in self._on_setup_computer_success:
                     function()
                 return True
             except common.NotExistent:
@@ -780,10 +780,13 @@ class AiidaComputerSetup(ipw.VBox):
                 return False
 
             if self._configure_computer(computer):
-                for function in self.on_setup_computer_success:
+                for function in self._on_setup_computer_success:
                     function()
             print(f"Computer<{computer.pk}> {computer.label} created")
             return True
+
+    def on_setup_computer_success(self, function):
+        self._on_setup_computer_success.append(function)
 
     def test(self, _=None):
         with self._test_out:
@@ -833,7 +836,7 @@ class AiidaCodeSetup(ipw.VBox):
 
     def __init__(self, path_to_root="../", **kwargs):
 
-        self.on_setup_code_success = []
+        self._on_setup_code_success = []
 
         # Code label.
         self.label = ipw.Text(
@@ -956,12 +959,15 @@ class AiidaCodeSetup(ipw.VBox):
                 print(f"Unable to store the Code: {exception}")
                 return False
 
-            for function in self.on_setup_code_success:
+            for function in self._on_setup_code_success:
                 function()
 
             print(f"Code<{code.pk}> {code.full_label} created")
 
             return True
+
+    def on_setup_code_success(self, function):
+        self._on_setup_code_success.append(function)
 
     def _reset(self):
         self.label.value = ""

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -558,6 +558,8 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
                 "configure": config,
             }
 
+            self._code_changed()
+
     def _code_changed(self, _=None):
         """Update code settings."""
         with self.hold_trait_notifications():

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -1,6 +1,4 @@
 """Some utility functions used acrross the repository."""
-
-# +
 import threading
 
 import ipywidgets as ipw
@@ -8,8 +6,6 @@ import more_itertools as mit
 import numpy as np
 import traitlets
 from ase.io import read
-
-# -
 
 
 def valid_arguments(arguments, valid_args):
@@ -109,7 +105,6 @@ class PinholeCamera:
         return np.linalg.inv(self.matrix)
 
 
-# +
 class _StatusWidgetMixin(traitlets.HasTraits):
     """Show temporary messages for example for status updates.
     This is a mixin class that is meant to be part of an inheritance

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -1,5 +1,4 @@
 """Some utility functions used acrross the repository."""
-from functools import wraps
 
 import more_itertools as mit
 import numpy as np
@@ -84,36 +83,6 @@ def string_range_to_list(strng, shift=-1):
         except ValueError:
             return list(), False
     return singles, True
-
-
-def yield_for_change(widget, attribute):
-    """Pause a generator to wait for a widget change event.
-
-    Taken from: https://ipywidgets.readthedocs.io/en/7.6.5/examples/Widget%20Asynchronous.html#Generator-approach
-
-    This is a decorator for a generator function which pauses the generator on yield
-    until the given widget attribute changes. The new value of the attribute is
-    sent to the generator and is the value of the yield.
-    """
-
-    def f(iterator):
-        @wraps(iterator)
-        def inner():
-            i = iterator()
-
-            def next_i(change):
-                try:
-                    i.send(change.new)
-                except StopIteration:
-                    widget.unobserve(next_i, attribute)
-
-            widget.observe(next_i, attribute)
-            # start the generator
-            next(i)
-
-        return inner
-
-    return f
 
 
 class PinholeCamera:

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -1,8 +1,15 @@
 """Some utility functions used acrross the repository."""
 
+# +
+import threading
+
+import ipywidgets as ipw
 import more_itertools as mit
 import numpy as np
+import traitlets
 from ase.io import read
+
+# -
 
 
 def valid_arguments(arguments, valid_args):
@@ -100,3 +107,47 @@ class PinholeCamera:
     @property
     def inverse_matrix(self):
         return np.linalg.inv(self.matrix)
+
+
+# +
+class _StatusWidgetMixin(traitlets.HasTraits):
+    """Show temporary messages for example for status updates.
+    This is a mixin class that is meant to be part of an inheritance
+    tree of an actual widget with a 'value' traitlet that is used
+    to convey a status message. See the non-private classes below
+    for examples.
+    """
+
+    message = traitlets.Unicode(default_value="", allow_none=True)
+
+    def __init__(self, *args, **kwargs):
+        self._clear_timer = None
+        self._message_stack = []
+        super().__init__(*args, **kwargs)
+
+    def _clear_value(self):
+        """Set widget .value to be an empty string."""
+        if self._message_stack:
+            self._message_stack.pop(0)
+            self.value = "<br>".join(self._message_stack)
+        else:
+            self.value = ""
+
+    def show_temporary_message(self, value, clear_after=3):
+        """Show a temporary message and clear it after the given interval."""
+        self._message_stack.append(value)
+        self.value = "<br>".join(self._message_stack)
+
+        # Start new timer that will clear the value after the specified interval.
+        self._clear_timer = threading.Timer(clear_after, self._clear_value)
+        self._clear_timer.start()
+
+
+class StatusHTML(_StatusWidgetMixin, ipw.HTML):
+    """Show temporary HTML messages for example for status updates."""
+
+    # This method should be part of _StatusWidgetMixin, but that does not work
+    # for an unknown reason.
+    @traitlets.observe("message")
+    def _observe_message(self, change):
+        self.show_temporary_message(change["new"])

--- a/notebooks/setup_computer.ipynb
+++ b/notebooks/setup_computer.ipynb
@@ -125,7 +125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixes #301
In this PR the ComputationalResourcesWidget's behaviour is improved:
 - After each computer setup the code widget is refreshed.
 - After each code setup, the list of available codes is refreshed.

Additionally, there were a few changes to achieve the things mentioned above:
- `SshComputerSetup.on_setup_ssh()`, `AiidaComputerSetup.on_setup_computer()`,
`AiidaCodeSetup.on_setup_code()` are now returning `False` in case of a failure, and `True`
in case of a success.
- `AiidaCodeSetup.refresh()` method is implemented. It updates the content of the widget with
the latest changes.
- Simplify `ssh_copy_id` function that raises an `RuntimeError` in case the connection to a
remote computer couldn't  be established. The exception is then handled by the
`SshComputerSetup.on_setup_ssh()` method. 
