### PR TITLE
Fix node importer widget.

### DIFF
--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -301,7 +301,7 @@ class _AppIcon:
 
         name = app["name"]
         app_object = _AiidaLabApp.from_id(name)
-        self.logo = app_object.logo
+        self.logo = app_object.metadata["logo"]
         if app_object.is_installed():
             self.link = f"{path_to_root}{app['name']}/{app['notebook']}?{app['parameter_name']}={node.uuid}"
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 install_requires =
     aiida-core~=1.0
-    aiidalab>=21.07.3
+    aiidalab>=21.11.2
     aiidalab-eln~=0.1
     ansi2html~=1.6
     ase<3.20


### PR DESCRIPTION
In aiidalab>=21.11.2 the `_AiidaLabApp` stores logo not as an attribute
but as part of metadata.