### PR TITLE
Work on the `StatusHTML` widget.

### DIFF
--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -131,8 +131,8 @@ class _StatusWidgetMixin(traitlets.HasTraits):
             self.value = ""
 
     def show_temporary_message(self, value, clear_after=None):
-        clear_after = clear_after or self._clear_after
         """Show a temporary message and clear it after the given interval."""
+        clear_after = clear_after or self._clear_after
         if value:
             self._message_stack.append(value)
             self.value = self.new_line.join(self._message_stack)

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -140,7 +140,7 @@ class _StatusWidgetMixin(traitlets.HasTraits):
             # Start new timer that will clear the value after the specified interval.
             self._clear_timer = threading.Timer(self._clear_after, self._clear_value)
             self._clear_timer.start()
-            self.message = ""
+            self.message = None
 
 
 class StatusHTML(_StatusWidgetMixin, ipw.HTML):

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -130,7 +130,8 @@ class _StatusWidgetMixin(traitlets.HasTraits):
         else:
             self.value = ""
 
-    def show_temporary_message(self, value):
+    def show_temporary_message(self, value, clear_after=None):
+        clear_after = clear_after or self._clear_after
         """Show a temporary message and clear it after the given interval."""
         if value:
             self._message_stack.append(value)

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -114,9 +114,11 @@ class _StatusWidgetMixin(traitlets.HasTraits):
     """
 
     message = traitlets.Unicode(default_value="", allow_none=True)
+    new_line = "\n"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, clear_after=3, *args, **kwargs):
         self._clear_timer = None
+        self._clear_after = clear_after
         self._message_stack = []
         super().__init__(*args, **kwargs)
 
@@ -124,22 +126,26 @@ class _StatusWidgetMixin(traitlets.HasTraits):
         """Set widget .value to be an empty string."""
         if self._message_stack:
             self._message_stack.pop(0)
-            self.value = "<br>".join(self._message_stack)
+            self.value = self.new_line.join(self._message_stack)
         else:
             self.value = ""
 
-    def show_temporary_message(self, value, clear_after=3):
+    def show_temporary_message(self, value):
         """Show a temporary message and clear it after the given interval."""
-        self._message_stack.append(value)
-        self.value = "<br>".join(self._message_stack)
+        if value:
+            self._message_stack.append(value)
+            self.value = self.new_line.join(self._message_stack)
 
-        # Start new timer that will clear the value after the specified interval.
-        self._clear_timer = threading.Timer(clear_after, self._clear_value)
-        self._clear_timer.start()
+            # Start new timer that will clear the value after the specified interval.
+            self._clear_timer = threading.Timer(self._clear_after, self._clear_value)
+            self._clear_timer.start()
+            self.message = ""
 
 
 class StatusHTML(_StatusWidgetMixin, ipw.HTML):
     """Show temporary HTML messages for example for status updates."""
+
+    new_line = "<br>"
 
     # This method should be part of _StatusWidgetMixin, but that does not work
     # for an unknown reason.


### PR DESCRIPTION
- Introduce a `new_line` attribute that allows modifying the new line
symbol depending on the string type.
- Reset the `message` trait every time its value has been added to the
stack. This allows re-displaying the warning message even if the text
hasn't changed.
- Set the `clear_after` attribute at the moment of object construction.