### PR TITLE
SmilesWidget: Add basic error handling

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -654,12 +654,16 @@ class SmilesWidget(ipw.VBox):
 
         self.smiles = ipw.Text(placeholder="C=C")
         self.create_structure_btn = ipw.Button(
-            description="Generate molecule", button_style="info"
+            description="Generate molecule",
+            button_style="primary",
+            tooltip="Generate molecule from SMILES string",
         )
         self.create_structure_btn.on_click(self._on_button_pressed)
         self.output = ipw.HTML("")
 
-        super().__init__([self.smiles, self.create_structure_btn, self.output])
+        super().__init__(
+            [ipw.HBox([self.smiles, self.create_structure_btn]), self.output]
+        )
 
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -703,7 +703,6 @@ class SmilesWidget(ipw.VBox):
         from rdkit import Chem
         from rdkit.Chem import AllChem
 
-        smiles = smiles.replace("[", "").replace("]", "")
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             # Something is seriously wrong with the SMILES code,
@@ -728,7 +727,7 @@ class SmilesWidget(ipw.VBox):
             return self._rdkit_opt(smiles, steps)
         except ValueError as e:
             self.output.value = str(e)
-            self.output.value += " Trying OpebBabel..."
+            self.output.value += " Trying OpenBabel..."
             return self._pybel_opt(smiles, steps)
 
     def _on_button_pressed(self, change):  # pylint: disable=unused-argument

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -716,10 +716,11 @@ class SmilesWidget(ipw.VBox):
         mol = Chem.AddHs(mol)
 
         AllChem.EmbedMolecule(mol, maxAttempts=20, randomSeed=42)
-        if not AllChem.UFFHasAllMoleculeParams(mol):
-            raise ValueError("RDKit ERROR: Missing UFF parameters")
+        if AllChem.UFFHasAllMoleculeParams(mol):
+            AllChem.UFFOptimizeMolecule(mol, maxIters=steps)
+        else:
+            self.output.value = "RDKit WARNING: Missing UFF parameters"
 
-        AllChem.UFFOptimizeMolecule(mol, maxIters=steps)
         positions = mol.GetConformer().GetPositions()
         natoms = mol.GetNumAtoms()
         species = [mol.GetAtomWithIdx(j).GetSymbol() for j in range(natoms)]

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -737,7 +737,7 @@ class SmilesWidget(ipw.VBox):
 
         if not self.smiles.value:
             return
-        spinner = f"Screening possible conformers {self.SPINNER}" # font-size:20em;
+        spinner = f"Screening possible conformers {self.SPINNER}"  # font-size:20em;
         self.output.value = spinner
         self.structure = self._mol_from_smiles(self.smiles.value)
         # Don't overwrite possible error/warning messages


### PR DESCRIPTION
Extracted from #290 as a more conservative subset of the changes there.

I am also proposing some small style changes. Moving the Generate button next to the input field since there's plenty of space, and the space below can be used for notification area. I also changed the button style to 'primary' since it _is_ the primary button of this plugin (and I like the blue color better :-)). Feel free to push back on that though as it might not be consistent with the colors in other parts of the widgets. I have also added tooltips to hopefully improve accessibility.

I was also wondering whether we should be adding classes to some of the key UI elements, e.g.

```python
self.create_structure_btn.add_class("btn-generate-from-smiles")
```
This would for example make them easier targets in selenium tests.

BEFORE:
![image](https://user-images.githubusercontent.com/9539441/179609813-eeb1dbd4-e7b4-4c85-880f-b433c5069c26.png)

AFTER:
![image](https://user-images.githubusercontent.com/9539441/179610649-607112a0-901f-4657-a78e-1f44e4f7783c.png)


## Testing

1.  
input1: `c1cc1`
stderr: `RDKit ERROR: [19:58:16] Can't kekulize mol.  Unkekulized atoms: 0 1 2` 
input2: `Ch`
stderr: `RDKit ERROR: [20:01:52] SMILES Parse Error: syntax error while parsing: Ch
RDKit ERROR: [20:01:52] SMILES Parse Error: Failed parsing SMILES 'Ch' for input: 'Ch'`

Both of these would result in:
```
ArgumentError: Python argument types in
    rdkit.Chem.rdmolops.AddHs(NoneType)
did not match C++ signature:
    AddHs(RDKit::ROMol mol, bool explicitOnly=False, bool addCoords=False, boost::python::api::object onlyOnAtoms=None, bool addResidueInfo=False)
```
With this PR, we just print "ERROR: Invalid SMILES code"

2.  input: `CS(C)(C)=O`
This is actually a valid SMILES string, as discussed in https://github.com/rdkit/rdkit/issues/200. However, the UFF force field that we use for minimization is missing parameters for sulphur in this particular hybridization, so the rdkit minimization fails with
```
~/apps/aiidalab-widgets-base/aiidalab_widgets_base/structures.py in _rdkit_opt(self, smiles, steps)
    706 
    707         AllChem.EmbedMolecule(mol, maxAttempts=20, randomSeed=42)
--> 708         AllChem.UFFOptimizeMolecule(mol, maxIters=steps)
    709         positions = mol.GetConformer().GetPositions()
    710         natoms = mol.GetNumAtoms()

RuntimeError: Pre-condition Violation
	bad params pointer
	Violation occurred on line 75 in file Code/ForceField/UFF/AngleBend.cpp
	Failed Expression: at2Params
	RDKIT: 2020.09.1
	BOOST: 1_74
```
In the new code, if there are missing UFF parameters we skip the UFF optimization. 

3. input: `CC(C)(C)*OO`
For some reason, this one passes through rdkit even though it contains an invalid character `*`, and fails later in ASE, as described in #270. This PR does not solve this problem. We should probably treat this as an RDKit bug and open an isssue there.
