### PR TITLE
Update optimade database provider list

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -144,7 +144,7 @@ class OptimadeQueryWidget(ipw.VBox):
 
     :param embedded: Whether or not to show extra database and provider information.
         When set to `True`, the extra information will be hidden, this is useful
-        in situations where the widget is used in a Tab or similar, e.g., for the 
+        in situations where the widget is used in a Tab or similar, e.g., for the
         class :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
     :type embedded: bool
     :param title: Title used for Tab header if employed in

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -144,8 +144,8 @@ class OptimadeQueryWidget(ipw.VBox):
 
     :param embedded: Whether or not to show extra database and provider information.
         When set to `True`, the extra information will be hidden, this is useful
-        in situations where the widget is used in a Tab or similar, e.g., can be used
-        for the :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
+        in situations where the widget is used in a Tab or similar, e.g., for the 
+        class :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
     :type embedded: bool
     :param title: Title used for Tab header if employed in
         :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
@@ -157,7 +157,7 @@ class OptimadeQueryWidget(ipw.VBox):
     _disable_providers = DISABLE_PROVIDERS
     _skip_databases = SKIP_DATABASE
     _skip_providers = SKIP_PROVIDERS
-    _database_grouping = PROVIDER_DATABASE_GROUPINGS
+    _provider_database_groupings = PROVIDER_DATABASE_GROUPINGS
 
     def __init__(
         self,
@@ -173,9 +173,9 @@ class OptimadeQueryWidget(ipw.VBox):
             database_limit=kwargs.pop("database_limit", None),
             disable_providers=kwargs.pop("disable_providers", self._disable_providers),
             skip_databases=kwargs.pop("skip_databases", self._skip_databases),
-            skip_provider=kwargs.pop("skip_databases", self._skip_providers),
+            skip_providers=kwargs.pop("skip_providers", self._skip_providers),
             provider_database_groupings=kwargs.pop(
-                "provider_database_groupings", self._database_grouping
+                "provider_database_groupings", self._provider_database_groupings
             ),
         )
         filters = OptimadeQueryFilterWidget(

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -7,6 +7,12 @@ from aiida.tools.dbimporters.plugins.cod import CodDbImporter
 from ase import Atoms
 from optimade_client.query_filter import OptimadeQueryFilterWidget
 from optimade_client.query_provider import OptimadeQueryProviderWidget
+from optimade_client.parameters import (
+    PROVIDER_DATABASE_GROUPINGS, 
+    SKIP_DATABASE, 
+    SKIP_PROVIDERS, 
+    DISABLE_PROVIDERS,
+)
 from traitlets import Bool, Float, Instance, Int, Unicode, default, observe
 
 
@@ -148,32 +154,10 @@ class OptimadeQueryWidget(ipw.VBox):
 
     structure = Instance(Atoms, allow_none=True)
 
-    _disable_providers = [
-        "cod",
-        "tcod",
-        "nmd",
-        "oqmd",
-        "aflow",
-        "matcloud",
-        "mpds",
-        "necro",
-        "jarvis",
-        "ccpnc",
-    ]
-    _skip_databases = {"Materials Cloud": ["optimade-sample", "li-ion-conductors", "threedd", "sssp"]}
-    _database_grouping = {
-        "Materials Cloud": {
-            "Main Projects": ["mc3d-structures", "2dstructures"],
-            "Contributed Projects": [
-                "2dtopo",
-                "pyrene-mofs",
-                "scdm",
-                "stoceriaitf",
-                "tc-applicability",
-                "tin-antimony-sulfoiodide",
-                "curated-cofs",
-            ]}
-    }
+    _disable_providers = DISABLE_PROVIDERS
+    _skip_databases = SKIP_DATABASE
+    _skip_providers = SKIP_PROVIDERS
+    _database_grouping = PROVIDER_DATABASE_GROUPINGS
 
     def __init__(
         self,
@@ -189,6 +173,7 @@ class OptimadeQueryWidget(ipw.VBox):
             database_limit=kwargs.pop("database_limit", None),
             disable_providers=kwargs.pop("disable_providers", self._disable_providers),
             skip_databases=kwargs.pop("skip_databases", self._skip_databases),
+            skip_provider=kwargs.pop("skip_databases", self._skip_providers),
             provider_database_groupings=kwargs.pop(
                 "provider_database_groupings", self._database_grouping
             ),

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -5,7 +5,7 @@ import requests
 import traitlets
 from aiida.tools.dbimporters.plugins.cod import CodDbImporter
 from ase import Atoms
-from optimade_client.parameters import (
+from optimade_client.default_parameters import (
     DISABLE_PROVIDERS,
     PROVIDER_DATABASE_GROUPINGS,
     SKIP_DATABASE,

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -138,8 +138,8 @@ class OptimadeQueryWidget(ipw.VBox):
 
     :param embedded: Whether or not to show extra database and provider information.
         When set to `True`, the extra information will be hidden, this is useful
-        in situations where the widget is used in a Tab or similar, e.g., for the
-        :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
+        in situations where the widget is used in a Tab or similar, e.g., can be used
+        for the :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
     :type embedded: bool
     :param title: Title used for Tab header if employed in
         :class:`aiidalab_widgets_base.structures.StructureManagerWidget`.
@@ -158,22 +158,21 @@ class OptimadeQueryWidget(ipw.VBox):
         "mpds",
         "necro",
         "jarvis",
+        "ccpnc",
     ]
-    _skip_databases = {"Materials Cloud": ["optimade-sample", "li-ion-conductors"]}
+    _skip_databases = {"Materials Cloud": ["optimade-sample", "li-ion-conductors", "threedd", "sssp"]}
     _database_grouping = {
         "Materials Cloud": {
-            "General": ["curated-cofs"],
-            "Projects": [
-                "2dstructures",
+            "Main Projects": ["mc3d-structures", "2dstructures"],
+            "Contributed Projects": [
                 "2dtopo",
                 "pyrene-mofs",
                 "scdm",
-                "sssp",
                 "stoceriaitf",
                 "tc-applicability",
-                "threedd",
-            ],
-        },
+                "tin-antimony-sulfoiodide",
+                "curated-cofs",
+            ]}
     }
 
     def __init__(

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -5,14 +5,14 @@ import requests
 import traitlets
 from aiida.tools.dbimporters.plugins.cod import CodDbImporter
 from ase import Atoms
+from optimade_client.parameters import (
+    DISABLE_PROVIDERS,
+    PROVIDER_DATABASE_GROUPINGS,
+    SKIP_DATABASE,
+    SKIP_PROVIDERS,
+)
 from optimade_client.query_filter import OptimadeQueryFilterWidget
 from optimade_client.query_provider import OptimadeQueryProviderWidget
-from optimade_client.parameters import (
-    PROVIDER_DATABASE_GROUPINGS, 
-    SKIP_DATABASE, 
-    SKIP_PROVIDERS, 
-    DISABLE_PROVIDERS,
-)
 from traitlets import Bool, Float, Instance, Int, Unicode, default, observe
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     nbconvert<6
     nglview~=3.0
     numpy~=1.17
-    optimade-client~=2022.9.19
+    optimade-client==2022.9.19
     pandas~=1.0
     scikit-learn~=0.24
     spglib~=1.16

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     nbconvert<6
     nglview~=3.0
     numpy~=1.17
-    optimade-client==2022.4.20
+    optimade-client~=2022.6.23
     pandas~=1.0
     scikit-learn~=0.24
     spglib~=1.16

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     nbconvert<6
     nglview~=3.0
     numpy~=1.17
-    optimade-client~=2022.6.23
+    optimade-client~=2022.9.19
     pandas~=1.0
     scikit-learn~=0.24
     spglib~=1.16


### PR DESCRIPTION
It has to be updated here for optimade database providers if we don't want to set the list explicitly on QeApp. ~~I think the best solution is just to have the default list set on `optimade-client` as const variable and use it for both here and materials cloud optimade client.~~ I make PR https://github.com/CasperWA/voila-optimade-client/pull/449 to voila-optimade-client tool for the list. This PR relies on it.