### PR TITLE
Parse symmetry info and show in cell tab

### DIFF
--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -164,10 +164,10 @@ class StatusHTML(_StatusWidgetMixin, ipw.HTML):
         self.show_temporary_message(change["new"])
 
 
-def ase2spglib(cell: Atoms):
+def ase2spglib(ase_structure: Atoms):
     """convert ase Atoms instance to spglib cell"""
-    lattice = cell.get_cell()
-    positions = cell.get_scaled_positions()
-    numbers = cell.get_atomic_numbers()
+    lattice = ase_structure.get_cell()
+    positions = ase_structure.get_scaled_positions()
+    numbers = ase_structure.get_atomic_numbers()
 
     return (lattice, positions, numbers)

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -5,12 +5,8 @@ import ipywidgets as ipw
 import more_itertools as mit
 import numpy as np
 import traitlets
-from aiida.plugins import DataFactory
+from ase import Atoms
 from ase.io import read
-
-CifData = DataFactory("cif")  # pylint: disable=invalid-name
-StructureData = DataFactory("structure")  # pylint: disable=invalid-name
-TrajectoryData = DataFactory("array.trajectory")  # pylint: disable=invalid-name
 
 
 def valid_arguments(arguments, valid_args):
@@ -166,3 +162,12 @@ class StatusHTML(_StatusWidgetMixin, ipw.HTML):
     @traitlets.observe("message")
     def _observe_message(self, change):
         self.show_temporary_message(change["new"])
+
+
+def ase2spglib(cell: Atoms):
+    """convert ase Atoms instance to spglib cell"""
+    lattice = cell.get_cell()
+    positions = cell.get_scaled_positions()
+    numbers = cell.get_atomic_numbers()
+
+    return (lattice, positions, numbers)

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -6,8 +6,8 @@ import ipywidgets as ipw
 import more_itertools as mit
 import numpy as np
 import traitlets
-from ase import Atoms
 from aiida.plugins import DataFactory
+from ase import Atoms
 from ase.io import read
 
 CifData = DataFactory("cif")  # pylint: disable=invalid-name

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -1,5 +1,6 @@
 """Some utility functions used acrross the repository."""
 import threading
+from typing import Any, Tuple
 
 import ipywidgets as ipw
 import more_itertools as mit
@@ -164,8 +165,11 @@ class StatusHTML(_StatusWidgetMixin, ipw.HTML):
         self.show_temporary_message(change["new"])
 
 
-def ase2spglib(ase_structure: Atoms):
-    """convert ase Atoms instance to spglib cell"""
+def ase2spglib(ase_structure: Atoms) -> Tuple[Any, Any, Any]:
+    """
+    Convert ase Atoms instance to spglib cell in the format defined at
+    https://spglib.github.io/spglib/python-spglib.html#crystal-structure-cell
+    """
     lattice = ase_structure.get_cell()
     positions = ase_structure.get_scaled_positions()
     numbers = ase_structure.get_atomic_numbers()

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -7,7 +7,12 @@ import more_itertools as mit
 import numpy as np
 import traitlets
 from ase import Atoms
+from aiida.plugins import DataFactory
 from ase.io import read
+
+CifData = DataFactory("cif")  # pylint: disable=invalid-name
+StructureData = DataFactory("structure")  # pylint: disable=invalid-name
+TrajectoryData = DataFactory("array.trajectory")  # pylint: disable=invalid-name
 
 
 def valid_arguments(arguments, valid_args):

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -372,8 +372,10 @@ class _StructureDataBaseViewer(ipw.VBox):
                 spglib_structure, symprec=1e-5, angle_tolerance=1.0
             )
 
-            self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
-            self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
+            # 3-D structure, attach symmetry info
+            if all(self.ase_structure.pbc):
+                self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
+                self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
         else:
             self.cell_a.value = "<i><b>a</b></i>:"
             self.cell_b.value = "<i><b>b</b></i>:"
@@ -387,8 +389,6 @@ class _StructureDataBaseViewer(ipw.VBox):
             self.cell_beta.value = "&beta;:"
             self.cell_gamma.value = "&gamma;:"
 
-            self.cell_spacegroup.value = "Spacegroup: "
-            self.cell_hall.value = "Hall: "
 
     def _cell_tab(self):
         self.cell_a = ipw.HTML()
@@ -410,7 +410,7 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         return ipw.VBox(
             [
-                ipw.HTML("Length unit: angstrom"),
+                ipw.HTML("Length unit: angstrom (Å)"),
                 ipw.HBox(
                     [
                         ipw.VBox(

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -210,16 +210,16 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         # Constructing configuration box
         if len(configuration_tabs) != 0:
-            configuration_box = ipw.Tab(
+            self.configuration_box = ipw.Tab(
                 layout=ipw.Layout(flex="1 1 auto", width="auto")
             )
-            configuration_box.children = [
+            self.configuration_box.children = [
                 configuration_tabs_map[tab_title] for tab_title in configuration_tabs
             ]
 
             for i, title in enumerate(configuration_tabs):
-                configuration_box.set_title(i, title)
-            children = [ipw.HBox([view_box, configuration_box])]
+                self.configuration_box.set_title(i, title)
+            children = [ipw.HBox([view_box, self.configuration_box])]
             view_box.layout = {"width": "60%"}
         else:
             children = [view_box]
@@ -676,6 +676,10 @@ class _StructureDataBaseViewer(ipw.VBox):
     def _observe_selection(self, _=None):
         self.highlight_atoms(self.selection)
         self._selected_atoms.value = list_to_string_range(self.selection, shift=1)
+
+        # if atom selected from nglview, shift to selection tab
+        if self._selected_atoms.value:
+            self.configuration_box.selected_index = 1
 
     def apply_selection(self, _=None):
         """Apply selection specified in the text field."""

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -300,6 +300,7 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         return ipw.VBox(
             [
+                ipw.HTML("Length unit: Angstrom"),
                 ipw.HBox(
                     [
                         ipw.VBox(

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -160,7 +160,7 @@ class _StructureDataBaseViewer(ipw.VBox):
 
     :param configure_view: If True, add configuration tabs (deprecated)
     :type configure_view: bool
-    :param configuration_tabs: List of configuration tabs (default: ["Cell", "Selection", "Cell", "Download"])
+    :param configuration_tabs: List of configuration tabs (default: ["Selection", "Appearance", "Cell", "Download"])
     :type configure_view: list
     :param default_camera: default camera (orthographic|perspective), can be changed in the Appearance tab
     :type default_camera: string
@@ -179,7 +179,7 @@ class _StructureDataBaseViewer(ipw.VBox):
     def __init__(
         self,
         configure_view=True,
-        configuration_tabs=["Cell", "Selection", "Appearance", "Download"],
+        configuration_tabs=None,
         default_camera="orthographic",
         **kwargs,
     ):
@@ -209,7 +209,11 @@ class _StructureDataBaseViewer(ipw.VBox):
                 configuration_tabs.clear()
 
         # Constructing configuration box
+        if configuration_tabs is None:
+            configuration_tabs = ["Selection", "Appearance", "Cell", "Download"]
+
         if len(configuration_tabs) != 0:
+            self.selection_tab_idx = configuration_tabs.index("Selection")
             self.configuration_box = ipw.Tab(
                 layout=ipw.Layout(flex="1 1 auto", width="auto")
             )
@@ -406,7 +410,7 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         return ipw.VBox(
             [
-                ipw.HTML("Length unit: Angstrom"),
+                ipw.HTML("Length unit: angstrom"),
                 ipw.HBox(
                     [
                         ipw.VBox(
@@ -440,7 +444,7 @@ class _StructureDataBaseViewer(ipw.VBox):
                         ),
                         ipw.VBox(
                             [
-                                ipw.HTML("Symmetry infomation:"),
+                                ipw.HTML("Symmetry information:"),
                                 self.cell_spacegroup,
                                 self.cell_hall,
                             ],
@@ -677,9 +681,9 @@ class _StructureDataBaseViewer(ipw.VBox):
         self.highlight_atoms(self.selection)
         self._selected_atoms.value = list_to_string_range(self.selection, shift=1)
 
-        # if atom selected from nglview, shift to selection tab
+        # if atom is selected from nglview, shift to selection tab
         if self._selected_atoms.value:
-            self.configuration_box.selected_index = 1
+            self.configuration_box.selected_index = self.selection_tab_idx
 
     def apply_selection(self, _=None):
         """Apply selection specified in the text field."""

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -340,7 +340,7 @@ class _StructureDataBaseViewer(ipw.VBox):
 
     @observe("cell")
     def _observe_cell(self, _=None):
-        # only update cell info when it is a 3D structure. 
+        # only update cell info when it is a 3D structure.
         if self.cell and all(self.structure.pbc):
             self.cell_a.value = "<i><b>a</b></i>: {:.4f} {:.4f} {:.4f}".format(
                 *self.cell.array[0]
@@ -385,7 +385,6 @@ class _StructureDataBaseViewer(ipw.VBox):
             self.cell_alpha.value = "&alpha;:"
             self.cell_beta.value = "&beta;:"
             self.cell_gamma.value = "&gamma;:"
-
 
     def _cell_tab(self):
         self.cell_a = ipw.HTML()

--- a/metadata.json
+++ b/metadata.json
@@ -14,6 +14,7 @@
             "more_itertools~=8.0",
             "nglview~=3.0",
             "numpy~=1.17",
+            "spglib~=1.16",
             "optimade-client==2021.5.7",
             "pandas~=1.0",
             "scikit-learn~=0.24",

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     optimade-client==2022.4.20
     pandas~=1.0
     scikit-learn~=0.24
+    spglib~=1.16
     vapory~=0.1.2
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
- [x] ~~Move the cell tab to front~~ Can be set when create widget.
- [x] parse symmetry info using `spglib`
- [x] ~~Using `ase.Atom` instead of `ase.Cell` in `StructureDataViewer` as active traitslet talk to other widget.~~
- [x] Missing unit symbol 'Angstrom'
- [x] ~~drop `ase.Cell` for structure viewer, use only `ase.Atoms` as trait.~~
- [x] When atom selected, automatically change to 'selection' tab.