### PR TITLE
FEATURE: WorkChainNodeViewerWidget

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -2,6 +2,7 @@
 # pylint: disable=no-self-use
 
 import base64
+import re
 import warnings
 from copy import deepcopy
 
@@ -9,6 +10,7 @@ import ipywidgets as ipw
 import nglview
 import numpy as np
 import traitlets
+from aiida.cmdline.utils.common import get_workchain_report
 from aiida.orm import Node
 from ase import Atoms, neighborlist
 from ase.cell import Cell
@@ -1126,3 +1128,18 @@ class BandsDataViewer(ipw.VBox):
             show(plot)
         children = [out]
         super().__init__(children, **kwargs)
+
+
+@register_viewer_widget("process.workflow.workchain.WorkChainNode.")
+class WorkChainNodeViewerWidget(ipw.VBox):
+    def __init__(self, workchain, **kwargs):
+        self.workchain = workchain
+
+        # Displaying reports only from the selected workchain,
+        # NOT from its descendants
+        report = get_workchain_report(self.workchain, "REPORT", max_depth=1)
+        # Filter out the first column with dates
+        report = re.sub(r"^[0-9]{4}.*\| ([A-Z]+)\]", r"\1", report, flags=re.MULTILINE)
+        report = ipw.HTML(f"<pre>{report}</pre>")
+
+        super().__init__([report], **kwargs)


### PR DESCRIPTION
As a developer, I want to quickly inspect why a workchain exited with non-zero status or excepted, directly in the ProcessNodesTreeWidget. 

I have implemented a simple WorkChainNodeViewerWidget that essentially prints out the output of `verdi process report` command. I strip out the dates to make the output less noisy, and I only output reports from the selected workchain itself, not from its descendants, as it could get very big for large workflows.

Here's how it looks:

![obrazek](https://user-images.githubusercontent.com/9539441/182041611-e22e6d77-9fb5-4d13-a10c-7059b0adfaf6.png)
