### PR TITLE
NodesTreeWidget: Red icon for failed processes

### DIFF
--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -286,7 +286,7 @@ class NodesTreeWidget(ipw.Output):
                 else process_node.process_state
             )
             tree_node.icon_style = self.PROCESS_STATE_STYLE.get(
-                process_state, PROCESS_STATE_STYLE_DEFAULT
+                process_state, self.PROCESS_STATE_STYLE_DEFAULT
             )
 
     def update(self, _=None):

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -278,8 +278,12 @@ class NodesTreeWidget(ipw.Output):
         if isinstance(tree_node, AiidaProcessNodeTreeNode):
             process_node = load_node(tree_node.pk)
             tree_node.name = calc_info(process_node)
-            tree_node.icon_style = self.PROCESS_STATE_STYLE.get(
-                process_node.process_state, self.PROCESS_STATE_STYLE_DEFAULT
+            tree_node.icon_style = (
+                self.PROCESS_STATE_STYLE.get(
+                    process_node.process_state, self.PROCESS_STATE_STYLE_DEFAULT
+                )
+                if not process_node.is_failed
+                else "danger"
             )
 
     def update(self, _=None):

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -278,13 +278,10 @@ class NodesTreeWidget(ipw.Output):
         if isinstance(tree_node, AiidaProcessNodeTreeNode):
             process_node = load_node(tree_node.pk)
             tree_node.name = calc_info(process_node)
-            tree_node.icon_style = (
-                self.PROCESS_STATE_STYLE.get(
-                    process_node.process_state, self.PROCESS_STATE_STYLE_DEFAULT
-                )
-                if not process_node.is_failed
-                else "danger"
-            )
+            # Override the process state in case that the process node has failed:
+            # (This could be refactored with structural pattern matching with py>=3.10.)
+            process_state = ProcessState.EXCEPTED if process_node.is_failed else process_node.process_state
+            tree_node.icon_style = self.PROCESS_STATE_STYLE.get(process_state, PROCESS_STATE_STYLE_DEFAULT)
 
     def update(self, _=None):
         """Refresh nodes based on the latest state of the root process and its children."""

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -280,8 +280,14 @@ class NodesTreeWidget(ipw.Output):
             tree_node.name = calc_info(process_node)
             # Override the process state in case that the process node has failed:
             # (This could be refactored with structural pattern matching with py>=3.10.)
-            process_state = ProcessState.EXCEPTED if process_node.is_failed else process_node.process_state
-            tree_node.icon_style = self.PROCESS_STATE_STYLE.get(process_state, PROCESS_STATE_STYLE_DEFAULT)
+            process_state = (
+                ProcessState.EXCEPTED
+                if process_node.is_failed
+                else process_node.process_state
+            )
+            tree_node.icon_style = self.PROCESS_STATE_STYLE.get(
+                process_state, PROCESS_STATE_STYLE_DEFAULT
+            )
 
     def update(self, _=None):
         """Refresh nodes based on the latest state of the root process and its children."""


### PR DESCRIPTION
This has bugged me for a while. We were displaying green icon for processes that finished but had non-zero exit status.

BEFORE:
![obrazek](https://user-images.githubusercontent.com/9539441/182042947-6a5de60e-10ea-458d-b770-f49374742b62.png)

AFTER:
![obrazek](https://user-images.githubusercontent.com/9539441/182042976-5b403786-8886-410b-93dd-eb2fb5002997.png)