### PR TITLE
StructureUploadWidget: Handle invalid files

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -414,7 +414,9 @@ class StructureUploadWidget(ipw.VBox):
             try:
                 return CifData(file=io.BytesIO(content))
             except Exception as e:
-                self._status_message.message = f"Could not parse CIF file {fname}: {e}"
+                self._status_message.message = f"""
+                    <div class="alert alert-danger">Could not parse CIF file {fname}: {e}</div>
+                    """
                 return None
 
         with tempfile.NamedTemporaryFile(suffix=suffix) as temp_file:

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -411,12 +411,10 @@ class StructureUploadWidget(ipw.VBox):
     def _read_structure(self, fname, content):
         suffix = "".join(pathlib.Path(fname).suffixes)
         if suffix == ".cif":
-            from CifFile import StarError
-
             try:
                 return CifData(file=io.BytesIO(content))
-            except StarError:
-                self._status_message.message = f"Could not parse CIF file {fname}"
+            except Exception as e:
+                self._status_message.message = f"Could not parse CIF file {fname}: {e}"
                 return None
 
         with tempfile.NamedTemporaryFile(suffix=suffix) as temp_file:

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -4,6 +4,7 @@
 import datetime
 import functools
 import io
+import pathlib
 import tempfile
 from collections import OrderedDict
 
@@ -368,16 +369,23 @@ class StructureUploadWidget(ipw.VBox):
         Supported structure formats
         </a>"""
         )
+        self.output = ipw.HTML("")
         self.file_upload.observe(self._on_file_upload, names="value")
-        super().__init__(children=[self.file_upload, supported_formats])
+        super().__init__(children=[self.file_upload, supported_formats, self.output])
 
     def _validate_and_fix_ase_cell(self, ase_structure, vacuum_ang=10.0):
         """
         Checks if the ase Atoms object has a cell set,
         otherwise sets it to bounding box plus specified "vacuum" space
         """
+        if not ase_structure:
+            return None
+
         cell = ase_structure.cell
 
+        # TODO: Since AiiDA 2.0, zero cell is possible if PBC=false
+        # so we should honor that here and do not put artificial cell
+        # around gas phase molecules.
         if (
             np.linalg.norm(cell[0]) < 0.1
             or np.linalg.norm(cell[1]) < 0.1
@@ -393,19 +401,42 @@ class StructureUploadWidget(ipw.VBox):
 
     def _on_file_upload(self, change=None):
         """When file upload button is pressed."""
+        self.output.value = ""
         for fname, item in change["new"].items():
-            frmt = fname.split(".")[-1]
-            if frmt == "cif":
-                self.structure = CifData(file=io.BytesIO(item["content"]))
-            else:
-                with tempfile.NamedTemporaryFile(suffix=f".{frmt}") as temp_file:
-                    temp_file.write(item["content"])
-                    temp_file.flush()
-                    self.structure = self._validate_and_fix_ase_cell(
-                        get_ase_from_file(temp_file.name)
-                    )
+            self.structure = self._read_structure(fname, item["content"])
             self.file_upload.value.clear()
             break
+
+    def _read_structure(self, fname, content):
+        suffix = "".join(pathlib.Path(fname).suffixes)
+        if suffix == ".cif":
+            from CifFile import StarError
+
+            try:
+                return CifData(file=io.BytesIO(content))
+            except StarError:
+                self.output.value = f"Could not parse CIF file {fname}"
+                return None
+
+        with tempfile.NamedTemporaryFile(suffix=suffix) as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            try:
+                structures = get_ase_from_file(temp_file.name)
+            except ValueError as e:
+                self.output.value = f"ERROR: {e}"
+                return None
+            except KeyError:
+                self.output.value = f"ERROR: Could not parse file {fname}"
+                return None
+
+            if len(structures) > 1:
+                self.output.value = (
+                    f"ERROR: More than one structure found in file {fname}"
+                )
+                return None
+
+            return self._validate_and_fix_ase_cell(structures[0])
 
 
 class StructureExamplesWidget(ipw.VBox):
@@ -437,7 +468,7 @@ class StructureExamplesWidget(ipw.VBox):
         """When structure is selected."""
 
         self.structure = (
-            get_ase_from_file(self._select_structure.value)
+            get_ase_from_file(self._select_structure.value)[0]
             if self._select_structure.value
             else None
         )

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -426,24 +426,18 @@ class StructureUploadWidget(ipw.VBox):
                 structures = get_ase_from_file(temp_file.name)
             except ValueError as e:
                 self._status_message.message = f"""
-                    <div class="alert alert-info">
-                    <strong>ERROR: {e}</strong>
-                    </div>
+                    <div class="alert alert-danger">ERROR: {e}</div>
                     """
                 return None
             except KeyError:
                 self._status_message.message = f"""
-                    <div class="alert alert-info">
-                    <strong>ERROR: Could not parse file {fname}</strong>
-                    </div>
+                    <div class="alert alert-danger">ERROR: Could not parse file {fname}</div>
                     """
                 return None
 
             if len(structures) > 1:
                 self._status_message.message = f"""
-                    <div class="alert alert-info">
-                    <strong>ERROR: More than one structure found in file {fname}</strong>
-                    </div>
+                    <div class="alert alert-danger">ERROR: More than one structure found in file {fname}</div>
                     """
                 return None
 

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -36,15 +36,8 @@ def get_ase_from_file(fname, format=None):  # pylint: disable=redefined-builtin
     else:
         traj = read(fname, format=format, index=":")
     if not traj:
-        print(f"Could not read any information from the file {fname}")
-        return False
-    if len(traj) > 1:
-        print(
-            "Warning: Uploaded file {} contained more than one structure. Selecting the first one.".format(
-                fname
-            )
-        )
-    return traj[0]
+        raise ValueError(f"Could not read any information from the file {fname}")
+    return traj
 
 
 def find_ranges(iterable):

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -34,9 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "widget = StructureManagerWidget(\n",
@@ -48,7 +46,7 @@
     "        StructureExamplesWidget(\n",
     "            title=\"From Examples\",\n",
     "            examples=[\n",
-    "                (\"Silicon oxide\", \"miscellaneous/structures/SiO2.xyz\")\n",
+    "                (\"Silicon oxide\", \"../miscellaneous/structures/SiO2.xyz\")\n",
     "            ]),\n",
     "    ],\n",
     "    editors = [\n",


### PR DESCRIPTION
Added more error handling to StructureUploadWidget, using an HTML widget to output errors instead of print statements. 
Partly extracted from #332, but no support for TrajectoryData is added here, although I tried to refactor a bit in preparation for it.

Besides the added error handling, there are two functional changes that deserve discussion:

1. Fail if multiple structures are detected in the file, instead of just picking the first one. To me this seems like a safer approach (until we implement opt-in support for TrajectoryData).
2. I changed the signature of the `utils.get_ase_from_file` function so that it returns all read structures. It's up to the caller to decide what to do (see point 1). It's also up to the caller to catch any exceptions). I don't know if functions in `utils/` are considered part of the public API though, perhaps I should create a new function and deprecate the old one?