### PR TITLE
StructureBrowserWidget: Customizable query types

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -8,7 +8,6 @@ import pathlib
 import tempfile
 from collections import OrderedDict
 
-# ASE imports
 import ase
 import ipywidgets as ipw
 import numpy as np
@@ -29,12 +28,9 @@ from ase.data import chemical_symbols, covalent_radii
 from sklearn.decomposition import PCA
 from traitlets import Instance, Int, List, Unicode, Union, default, dlink, link, observe
 
-from aiidalab_widgets_base.utils import StatusHTML
-
-from .data import LigandSelectorWidget
-
 # Local imports
-from .utils import get_ase_from_file
+from .data import LigandSelectorWidget
+from .utils import StatusHTML, get_ase_from_file, get_formula
 from .viewers import StructureDataViewer
 
 CifData = DataFactory("cif")  # pylint: disable=invalid-name
@@ -484,15 +480,24 @@ class StructureExamplesWidget(ipw.VBox):
 
 
 class StructureBrowserWidget(ipw.VBox):
-    """Class to query for structures stored in the AiiDA database."""
+    """Class to query for structures stored in the AiiDA database.
+
+    :param title: Title of the widget displayed on a tab in StructureManagerWidget
+    :type title: string
+    :param query_structure_type: A tuple of Data node types that are searched (default: StructureData, CifData)
+    :type query_structure_type: tuple
+    """
 
     structure = Union([Instance(Atoms), Instance(Data)], allow_none=True)
 
-    def __init__(self, title=""):
+    def __init__(self, title="", query_types=None):
         self.title = title
 
         # Structure objects we want to query for.
-        self.query_structure_type = (DataFactory("structure"), DataFactory("cif"))
+        if query_types:
+            self.query_structure_type = query_types
+        else:
+            self.query_structure_type = (DataFactory("structure"), DataFactory("cif"))
 
         # Extracting available process labels.
         qbuilder = QueryBuilder().append((CalcJobNode, WorkChainNode), project="label")
@@ -559,11 +564,10 @@ class StructureBrowserWidget(ipw.VBox):
         )
         for item in queryb.all():  # iterall() would interfere with set_extra()
             try:
-                formula = item[0].get_formula()
-            except AttributeError:
-                # Slow part.
-                formula = item[0].get_ase().get_chemical_formula()
-            item[0].set_extra("formula", formula)
+                formula = get_formula(item[0])
+                item[0].set_extra("formula", formula)
+            except ValueError:
+                pass
 
     def search(self, _=None):
         """Launch the search of structures in AiiDA database."""
@@ -638,7 +642,7 @@ class StructureBrowserWidget(ipw.VBox):
         for mch in matches:
             label = f"PK: {mch.id}"
             label += " | " + mch.ctime.strftime("%Y-%m-%d %H:%M")
-            label += " | " + mch.get_extra("formula")
+            label += " | " + mch.get_extra("formula", "")
             label += " | " + mch.node_type.split(".")[-2]
             label += " | " + mch.label
             label += " | " + mch.description
@@ -651,7 +655,7 @@ class StructureBrowserWidget(ipw.VBox):
 
 
 class SmilesWidget(ipw.VBox):
-    """Conver SMILES into 3D structure."""
+    """Convert SMILES into 3D structure."""
 
     structure = Instance(Atoms, allow_none=True)
 

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -484,8 +484,8 @@ class StructureBrowserWidget(ipw.VBox):
 
     :param title: Title of the widget displayed on a tab in StructureManagerWidget
     :type title: string
-    :param query_structure_type: A tuple of Data node types that are searched (default: StructureData, CifData)
-    :type query_structure_type: tuple
+    :param query_types: A tuple of Data node types that are searched (default: StructureData, CifData)
+    :type query_types: tuple
     """
 
     structure = Union([Instance(Atoms), Instance(Data)], allow_none=True)

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -497,7 +497,7 @@ class StructureBrowserWidget(ipw.VBox):
         if query_types:
             self.query_structure_type = query_types
         else:
-            self.query_structure_type = (DataFactory("structure"), DataFactory("cif"))
+            self.query_structure_type = (StructureData, CifData)
 
         # Extracting available process labels.
         qbuilder = QueryBuilder().append((CalcJobNode, WorkChainNode), project="label")

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -5,7 +5,12 @@ import ipywidgets as ipw
 import more_itertools as mit
 import numpy as np
 import traitlets
+from aiida.plugins import DataFactory
 from ase.io import read
+
+CifData = DataFactory("cif")  # pylint: disable=invalid-name
+StructureData = DataFactory("structure")  # pylint: disable=invalid-name
+TrajectoryData = DataFactory("array.trajectory")  # pylint: disable=invalid-name
 
 
 def valid_arguments(arguments, valid_args):
@@ -79,6 +84,21 @@ def string_range_to_list(strng, shift=-1):
         except ValueError:
             return list(), False
     return singles, True
+
+
+def get_formula(data_node):
+    """A wrapper for getting a molecular formula out of the AiiDA Data node"""
+    if isinstance(data_node, TrajectoryData):
+        # TrajectoryData can only hold structures with the same chemical formula,
+        # so this approach is sound.
+        stepid = data_node.get_stepids()[0]
+        return data_node.get_step_structure(stepid).get_formula()
+    elif isinstance(data_node, StructureData):
+        return data_node.get_formula()
+    elif isinstance(data_node, CifData):
+        return data_node.get_ase().get_chemical_formula()
+    else:
+        raise ValueError(f"Cannot get formula from node {type(data_node)}")
 
 
 class PinholeCamera:


### PR DESCRIPTION
By default, StructureBrowserWidget returns CifData and StructureData nodes. In this PR, we add the class constructor argument  `structure_query_type` to make this customizable. The programmer can decide to only search for CifData or StructureData, or in my particular use case to extend the search for TrajectoryData.

Partly extracted from #332. 

@yakutovicha we've discussed that we could create a general NodeBrowserWidget and deprecate the StructureBrowserWidget. However, upon closer inspection, the StructureBrowserWidget contains a lot of code that only make sense for structure-like nodes. Creating a generalized browser widget might still be useful in the future, but I suspect in most cases the widget would still need to be specialized to make it useful to a particular use case. The `ProcessListWidget` is one such example. Here I simply submit a minimal PR to support my use case.