### PR TITLE
ComputationalResourceWidget: Hide comp_resources_database if it is empty

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -57,7 +57,10 @@ class ComputationalResourcesWidget(ipw.VBox):
         self.output = ipw.HTML()
         self.setup_message = StatusHTML()
         self.code_select_dropdown = ipw.Dropdown(
-            description=description, disabled=True, value=None
+            description=description,
+            disabled=True,
+            value=None,
+            style={"description_width": "initial"},
         )
         traitlets.link((self, "codes"), (self.code_select_dropdown, "options"))
         traitlets.link((self.code_select_dropdown, "value"), (self, "value"))

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -128,7 +128,7 @@ class ComputationalResourcesWidget(ipw.VBox):
         # Quick setup.
         quick_setup_button = ipw.Button(description="Quick Setup")
         quick_setup_button.on_click(self.quick_setup)
-        quick_setup = ipw.VBox(
+        self.quick_setup = ipw.VBox(
             children=[
                 self.ssh_computer_setup.username,
                 quick_setup_button,
@@ -137,20 +137,16 @@ class ComputationalResourcesWidget(ipw.VBox):
         )
 
         # Detailed setup.
-        detailed_setup = ipw.Accordion(
+        self.detailed_setup = ipw.Accordion(
             children=[
                 self.ssh_computer_setup,
                 self.aiida_computer_setup,
                 self.aiida_code_setup,
             ]
         )
-        detailed_setup.set_title(0, "Set up password-less SSH connection")
-        detailed_setup.set_title(1, "Set up a computer in AiiDA")
-        detailed_setup.set_title(2, "Set up a code in AiiDA")
-
-        self.output_tab = ipw.Tab(children=[quick_setup, detailed_setup])
-        self.output_tab.set_title(0, "Quick Setup")
-        self.output_tab.set_title(1, "Detailed Setup")
+        self.detailed_setup.set_title(0, "Set up password-less SSH connection")
+        self.detailed_setup.set_title(1, "Set up a computer in AiiDA")
+        self.detailed_setup.set_title(2, "Set up a code in AiiDA")
 
         self.refresh()
 
@@ -232,18 +228,26 @@ class ComputationalResourcesWidget(ipw.VBox):
                     "width": "500px",
                     "border": "1px solid gray",
                 }
-                children = (
-                    [
+                if self.comp_resources_database.database:
+                    setup_tab = ipw.Tab(
+                        children=[self.quick_setup, self.detailed_setup]
+                    )
+                    setup_tab.set_title(0, "Quick Setup")
+                    setup_tab.set_title(1, "Detailed Setup")
+                    children = [
                         ipw.HTML(
                             """Please select the computer/code from a database to pre-fill the fields below."""
                         ),
                         self.comp_resources_database,
                         self.ssh_computer_setup.password_box,
+                        self.setup_message,
+                        setup_tab,
                     ]
-                    if self.comp_resources_database.database
-                    else []
-                )
-                children += [self.setup_message, self.output_tab]
+                else:
+                    # Display only Detailed Setup if DB is empty
+                    setup_tab = ipw.Tab(children=[self.detailed_setup])
+                    setup_tab.set_title(0, "Detailed Setup")
+                    children = [self.setup_message, setup_tab]
                 display(*children)
             else:
                 self._setup_new_code_output.layout = {

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -229,15 +229,19 @@ class ComputationalResourcesWidget(ipw.VBox):
                     "width": "500px",
                     "border": "1px solid gray",
                 }
-                display(
-                    ipw.HTML(
-                        """Please select the computer/code from a database to pre-fill the fields below."""
-                    ),
-                    self.comp_resources_database,
-                    self.setup_message,
-                    self.ssh_computer_setup.password_box,
-                    self.output_tab,
+                children = (
+                    [
+                        ipw.HTML(
+                            """Please select the computer/code from a database to pre-fill the fields below."""
+                        ),
+                        self.comp_resources_database,
+                        self.ssh_computer_setup.password_box,
+                    ]
+                    if self.comp_resources_database.database
+                    else []
                 )
+                children += [self.setup_message, self.output_tab]
+                display(*children)
             else:
                 self._setup_new_code_output.layout = {
                     "width": "500px",


### PR DESCRIPTION
As a developer I'd like to switch from the deprecated CodeDropdown to ComputerResourceWidget. 
The new widget is nice, but since I am not using any of the Swiss computer clusters, it is more noisy then what I had before without the added convenience.

Regardless of my use case. there's no point in displaying an empty widgets if the selected `input_plugin` is not available in any of the computers in the database (such as the case for ORCA program). In this case all the dropdowns are empty.

**Before:**
![image](https://user-images.githubusercontent.com/9539441/184791747-2afb55f2-6cd2-45da-9db3-1ab228fd8a2d.png)

**After:**
![image](https://user-images.githubusercontent.com/9539441/184794243-1ac55e7f-6c8f-4a6d-83af-e6a32f703299.png)


It's not clear to me how the Quick Setup works and whether it makes sense to display it in this scenario.