### PR TITLE
StructureUploadWidget: Multiple structures from a single file

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -33,8 +33,8 @@ from .data import LigandSelectorWidget
 from .utils import StatusHTML, get_ase_from_file, get_formula
 from .viewers import StructureDataViewer
 
-CifData = DataFactory("cif")  # pylint: disable=invalid-name
-StructureData = DataFactory("structure")  # pylint: disable=invalid-name
+CifData = DataFactory("cif")
+StructureData = DataFactory("structure")
 TrajectoryData = DataFactory("array.trajectory")
 
 SYMBOL_RADIUS = {key: covalent_radii[i] for i, key in enumerate(chemical_symbols)}

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -357,7 +357,7 @@ class StructureUploadWidget(ipw.VBox):
     structure = Union([Instance(Atoms), Instance(Data)], allow_none=True)
 
     def __init__(
-        self, title="", description="Upload Structure", multiple_structures=False
+        self, title="", description="Upload Structure", allow_trajectories=False
     ):
         self.title = title
         self.file_upload = ipw.FileUpload(
@@ -365,7 +365,7 @@ class StructureUploadWidget(ipw.VBox):
         )
         # Whether to allow uploading multiple structures from a single file.
         # In this case, we create TrajectoryData node.
-        self.multiple_structures = multiple_structures
+        self.allow_trajectories = allow_trajectories
         supported_formats = ipw.HTML(
             """<a href="https://wiki.fysik.dtu.dk/ase/ase/io/io.html#ase.io.write" target="_blank">
         Supported structure formats
@@ -441,7 +441,7 @@ class StructureUploadWidget(ipw.VBox):
                 return None
 
             if len(structures) > 1:
-                if self.multiple_structures:
+                if self.allow_trajectories:
                     return TrajectoryData(
                         structurelist=[
                             StructureData(

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -33,11 +33,13 @@ def predefine_settings(obj, **kwargs):
         if hasattr(obj, key):
             setattr(obj, key, value)
         else:
-            raise AttributeError(f"'{obj}' object has no attirubte '{key}'")
+            raise AttributeError(f"'{obj}' object has no attribute '{key}'")
 
 
 def get_ase_from_file(fname, format=None):  # pylint: disable=redefined-builtin
     """Get ASE structure object."""
+    # store_tags parameter is useful for CIF files
+    # https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#cif
     if format == "cif":
         traj = read(fname, format=format, index=":", store_tags=True)
     else:


### PR DESCRIPTION
By default, we do not allow multiple structures in a single file that is being uploaded.
Here I introduce an option to allow this and returning a TrajectoryData node in such cases.

Extracted from #332.

CC @yakutovicha 
