### PR TITLE
Use UUID rather than the aiida node instance as traitlet

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -4,13 +4,13 @@ import subprocess
 import threading
 from copy import copy
 from pathlib import Path
+from uuid import UUID
 
 import ipywidgets as ipw
 import pexpect
 import shortuuid
 import traitlets
 from aiida import common, orm, plugins
-from aiida.common.exceptions import NotExistent
 from aiida.orm.utils.builders.code import CodeBuilder
 from aiida.orm.utils.builders.computer import ComputerBuilder
 from aiida.transports.plugins.ssh import parse_sshconfig
@@ -207,10 +207,10 @@ class ComputationalResourcesWidget(ipw.VBox):
             return None
 
         try:
-            _ = orm.load_code(code_uuid)
-        except NotExistent:
-            self.output.value = f"""The supplied code UUID '<span style="color:red">{code_uuid}</span>'
-                was not found in the AiiDA database."""
+            _ = UUID(code_uuid, version=4)
+        except ValueError:
+            self.output.value = f"""'<span style="color:red">{code_uuid}</span>'
+            is not a valid UUID."""
         else:
             return code_uuid
 
@@ -1148,9 +1148,9 @@ class ComputerDropdownWidget(ipw.VBox):
             return None
 
         try:
-            _ = orm.load_computer(computer_uuid)
-        except NotExistent:
-            self.output.value = f"""The computer UUID '<span style="color:red">{computer_uuid}</span>'
-                supplied was not found in the AiiDA database."""
+            _ = UUID(computer_uuid, version=4)
+        except ValueError:
+            self.output.value = f"""'<span style="color:red">{computer_uuid}</span>'
+            is not a valid UUID."""
         else:
             return computer_uuid

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -27,13 +27,13 @@ class ComputationalResourcesWidget(ipw.VBox):
     """Code selection widget.
     Attributes:
 
-    value(Unicode or uuid of the code node): Trait that points to
-    the selected uuid of the code instance.
-    It can be set either to an AiiDA code uuid or to a code label.
+    value(Unicode or UUID of the code node): Trait that points to
+    the selected UUID of the code instance.
+    It can be set either to an AiiDA code UUID or to a code label.
     It is linked to the 'value' trait of
     the `self.code_select_dropdown` widget.
 
-    codes(Dict): Trait that contains a dictionary (label => Code uuid) for all
+    codes(Dict): Trait that contains a dictionary (label => Code UUID) for all
     codes found in the AiiDA database for the selected plugin. It is linked
     to the 'options' trait of the `self.code_select_dropdown` widget.
 
@@ -210,7 +210,7 @@ class ComputationalResourcesWidget(ipw.VBox):
             try:
                 _ = orm.load_code(code_uuid)
             except NotExistent:
-                self.output.value = f"""The code uuid '<span style="color:red">{code_uuid}</span>'
+                self.output.value = f"""The code UUID '<span style="color:red">{code_uuid}</span>'
                     supplied was not found in the AiiDA database."""
             else:
                 return code_uuid
@@ -1069,11 +1069,11 @@ class ComputerDropdownWidget(ipw.VBox):
     """Widget to select a configured computer.
 
     Attributes:
-        selected_computer(Unicode of computer uuid): Trait that points to the selected Computer instance.
-            It can be set to an AiiDA Computer uuid. It is linked to the
+        selected_computer(Unicode of computer UUID): Trait that points to the selected Computer instance.
+            It can be set to an AiiDA Computer UUID. It is linked to the
             'value' trait of `self._dropdown` widget.
 
-        computers(Dict): Trait that contains a dictionary (label => Computer uuid) for all
+        computers(Dict): Trait that contains a dictionary (label => Computer UUID) for all
         computers found in the AiiDA database. It is linked to the 'options' trait of
         `self._dropdown` widget.
 
@@ -1154,7 +1154,7 @@ class ComputerDropdownWidget(ipw.VBox):
             try:
                 _ = orm.load_computer(computer_uuid)
             except NotExistent:
-                self.output.value = f"""The computer uuid '<span style="color:red">{computer_uuid}</span>'
+                self.output.value = f"""The computer UUID '<span style="color:red">{computer_uuid}</span>'
                     supplied was not found in the AiiDA database."""
             else:
                 return computer_uuid

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -197,8 +197,8 @@ class ComputationalResourcesWidget(ipw.VBox):
 
     @traitlets.validate("value")
     def _validate_value(self, change):
-        """If code is provided, set it as it is. If code's label is provided,
-        select the code and set it."""
+        """If code is provided, set it as it is. If code's UUID is provided,
+        check it is valid in DB"""
         code_uuid = change["value"]
         self.output.value = ""
 
@@ -206,17 +206,13 @@ class ComputationalResourcesWidget(ipw.VBox):
         if code_uuid is None:
             return None
 
-        if isinstance(code_uuid, str):  # Check code by label.
-            try:
-                _ = orm.load_code(code_uuid)
-            except NotExistent:
-                self.output.value = f"""The code UUID '<span style="color:red">{code_uuid}</span>'
-                    supplied was not found in the AiiDA database."""
-            else:
-                return code_uuid
-
-        # This place will never be reached, because the trait's type is checked.
-        return None
+        try:
+            _ = orm.load_code(code_uuid)
+        except NotExistent:
+            self.output.value = f"""The supplied code UUID '<span style="color:red">{code_uuid}</span>'
+                was not found in the AiiDA database."""
+        else:
+            return code_uuid
 
     def _setup_new_code(self, _=None):
         with self._setup_new_code_output:
@@ -1145,18 +1141,16 @@ class ComputerDropdownWidget(ipw.VBox):
 
     @traitlets.validate("value")
     def _validate_value(self, change):
-        """Select computer either by label or by class instance."""
+        """Select computer either by computer UUID."""
         computer_uuid = change["value"]
         self.output.value = ""
         if not computer_uuid:
             return None
-        if isinstance(computer_uuid, str):
-            try:
-                _ = orm.load_computer(computer_uuid)
-            except NotExistent:
-                self.output.value = f"""The computer UUID '<span style="color:red">{computer_uuid}</span>'
-                    supplied was not found in the AiiDA database."""
-            else:
-                return computer_uuid
 
-        return None
+        try:
+            _ = orm.load_computer(computer_uuid)
+        except NotExistent:
+            self.output.value = f"""The computer UUID '<span style="color:red">{computer_uuid}</span>'
+                supplied was not found in the AiiDA database."""
+        else:
+            return computer_uuid


### PR DESCRIPTION
From AiiDA 2.x every orm entity instance is now tied to a specific storage instance (which is connected to the database).
So once the storage instance is closed (and so close the connection), then those orm instances are now "dead" and can not be used for other reloaded sessions. 

Since this requires changing the API of the `ComputationalResourceWidget`, I create this dedicated PR for it. 
Do we also consider the back-ward compatibility or do we just leave this all to the 2.x support by put all these changes to #344 ?