### PR TITLE
Refac: remove unsed hold_trait_notification for resource setup widget

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -473,15 +473,14 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
         return database
 
     def update(self, _=None):
-        with self.hold_trait_notifications():
-            database = requests.get(
-                "https://aiidateam.github.io/aiida-code-registry/database.json"
-            ).json()
-            self.database = (
-                self.clean_up_database(database, self.input_plugin)
-                if self.input_plugin
-                else database
-            )
+        database = requests.get(
+            "https://aiidateam.github.io/aiida-code-registry/database.json"
+        ).json()
+        self.database = (
+            self.clean_up_database(database, self.input_plugin)
+            if self.input_plugin
+            else database
+        )
 
     @traitlets.observe("database")
     def _observer_database_change(self, _=None):


### PR DESCRIPTION
As mentioned at https://github.com/aiidalab/aiidalab-widgets-base/pull/344#discussion_r979854583, the `hold_trait_notification` is not necessary for this database fetch function, removed.