### PR TITLE
fix bug when removing atoms 

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -1331,4 +1331,4 @@ class BasicStructureEditor(ipw.VBox):  # pylint: disable=too-many-instance-attri
         """Remove selected atoms."""
         del [atoms[selection]]
 
-        self.structure, self.selection = atoms, selection
+        self.structure, self.selection = atoms, list()


### PR DESCRIPTION
When deleting  atoms the selection should be set to an empty list otherwise the visualizer may crash 