### PR TITLE
fix _status_message error

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -882,6 +882,7 @@ class BasicCellEditor(ipw.VBox):
 
     def __init__(self, title="Cell transform"):
         self.title = title
+        self._status_message = StatusHTML()
 
         # cell transfor opration widget
         primitive_cell = ipw.Button(
@@ -904,6 +905,7 @@ class BasicCellEditor(ipw.VBox):
                         conventional_cell,
                     ],
                 ),
+                self._status_message,
             ],
         )
 


### PR DESCRIPTION
Added a `_status_message` attribute to `BasicCellEditor`. Fixed a bug which is described below:

## System Information
- Docker image: latest version of 'aiidalab/aiidalab-docker-stack:latest'
- aiidalab-widgets-base: commit d74601e5fee563a3c1abe844beef805254edaaa3,  #327 

## Exact steps for others to reproduce the error
- Open aiidalab-qe
- Go the `Edit Structure` --> `Edit Cell`
- Click `Convert to primitive cell`

## Expected results
`Oh no... the application crashed due to an unexpected error.`

## Python traceback


```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/apps/aiidalab-widgets-base/aiidalab_widgets_base/structures.py in inner(ref, *args, **kwargs)
    830 
    831         if not ref.structure:
--> 832             ref._status_message.message = """
    833             <div class="alert alert-info">
    834             <strong>Please choose a structure first.</strong>

AttributeError: 'BasicCellEditor' object has no attribute '_status_message'
```
