### PR TITLE
Fix: Do not assume Selection tab in StructureDataViewer

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -212,8 +212,12 @@ class _StructureDataBaseViewer(ipw.VBox):
         if configuration_tabs is None:
             configuration_tabs = ["Selection", "Appearance", "Cell", "Download"]
 
+        self.selection_tab_idx = None
         if len(configuration_tabs) != 0:
-            self.selection_tab_idx = configuration_tabs.index("Selection")
+            try:
+                self.selection_tab_idx = configuration_tabs.index("Selection")
+            except ValueError:
+                pass
             self.configuration_box = ipw.Tab(
                 layout=ipw.Layout(flex="1 1 auto", width="auto")
             )
@@ -679,7 +683,7 @@ class _StructureDataBaseViewer(ipw.VBox):
         self._selected_atoms.value = list_to_string_range(self.selection, shift=1)
 
         # if atom is selected from nglview, shift to selection tab
-        if self._selected_atoms.value:
+        if self._selected_atoms.value and self.selection_tab_idx is not None:
             self.configuration_box.selected_index = self.selection_tab_idx
 
     def apply_selection(self, _=None):


### PR DESCRIPTION
Passing an empty `configuration_tabs` to StructureDataViewer would throw a ValueError, because the code would assume that the Selection tab is always present.