### PR TITLE
10 mins are too short for notebook CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             fail-fast: false
 
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        timeout-minutes: 20
 
         steps:
 


### PR DESCRIPTION
With new pytest-docker test based on full-stack, the CI action terminated at 10 mins which is too short.