### PR TITLE
clean up dependencies requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,25 +19,18 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    aiida-core>=2.0,<3
-    aiidalab>=21.11.2
+    aiida-core[atomic-tools]>=2.0,<3
     aiidalab-eln>=0.1.2,~=0.1
     ansi2html~=1.6
-    ase<3.20
     bokeh~=2.0
     humanfriendly~=10.0
     ipytree~=0.2
-    ipywidgets~=7.6
-    jupyter-client<7
     more-itertools~=8.0
-    nbconvert<6
     nglview~=3.0
-    numpy~=1.17
     optimade-client==2022.9.19
-    pandas~=1.0
     scikit-learn~=0.24
-    spglib~=1.16
     vapory~=0.1.2
+    ipywidgets~=7.7
 python_requires = >=3.8
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,21 +19,21 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    PyCifRW~=4.4
     aiida-core>=2.0,<3
     aiidalab-eln>=0.1.2,~=0.1
     ansi2html~=1.6
+    ase~=3.18
     bokeh~=2.0
     humanfriendly~=10.0
     ipytree~=0.2
+    ipywidgets~=7.7
     more-itertools~=8.0
     nglview~=3.0
     optimade-client==2022.9.19
     scikit-learn~=0.24
-    vapory~=0.1.2
-    ipywidgets~=7.7
-    PyCifRW~=4.4
-    ase~=3.18
     spglib~=1.14
+    vapory~=0.1.2
 python_requires = >=3.8
 include_package_data = True
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    aiida-core[atomic-tools]>=2.0,<3
+    aiida-core>=2.0,<3
     aiidalab-eln>=0.1.2,~=0.1
     ansi2html~=1.6
     bokeh~=2.0
@@ -31,6 +31,9 @@ install_requires =
     scikit-learn~=0.24
     vapory~=0.1.2
     ipywidgets~=7.7
+    PyCifRW~=4.4
+    ase~=3.18
+    spglib~=1.14
 python_requires = >=3.8
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
The principle of my cleaning process is the packages in the list do not conflict with each other and do not duplicate. For example, if the package is installed by aiida-core dep, it should not be specified again in the list.
As for the jupyter backend packages, there is no need to install then, since 

`aiida-core` > 2 will lead to install `numpy~=1.19` therefore `numpy~=1.23` is installed.
- numpy~=1.17

The following packages are even in conflict and will override the deps which causes the Jupyter engine to fail, we need to pining version when we find future confliction.
- `jupyter-client<7`
- `nbconvert<6`

- `aiidalab>=21.11.2` is already pinned in the stack
