### PR TITLE
Require aiida-core>=2.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     PyCifRW~=4.4
-    aiida-core>=2.0,<3
+    aiida-core>=2.1,<3
     aiidalab>=21.11.2
     aiidalab-eln>=0.1.2,~=0.1
     ansi2html~=1.6


### PR DESCRIPTION
I believe since we switched to the new `code create` API in #394, we need to require AiiDA 2.1