### PR TITLE
code quick setup can have computer label in its dropdown as placeholder before computer is set

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -11,9 +11,9 @@ import pexpect
 import shortuuid
 import traitlets
 from aiida import common, orm, plugins
+from aiida.common.exceptions import NotExistent
 from aiida.orm.utils.builders.computer import ComputerBuilder
 from aiida.transports.plugins.ssh import parse_sshconfig
-from aiida.common.exceptions import NotExistent
 from humanfriendly import InvalidSize, parse_size
 from IPython.display import clear_output, display
 
@@ -999,7 +999,7 @@ class AiidaCodeSetup(ipw.VBox):
             style=STYLE,
         )
 
-        self.remote_abs_path = ipw.Text(
+        self.filepath_executable = ipw.Text(
             placeholder="/path/to/executable",
             description="Absolute path to executable:",
             layout=LAYOUT,
@@ -1033,7 +1033,7 @@ class AiidaCodeSetup(ipw.VBox):
             self.computer,
             self.default_calc_job_plugin,
             self.description,
-            self.remote_abs_path,
+            self.filepath_executable,
             self.use_double_quotes,
             self.prepend_text,
             self.append_text,
@@ -1068,6 +1068,9 @@ class AiidaCodeSetup(ipw.VBox):
             ]
 
             kwargs = {key: getattr(self, key).value for key in items_to_configure}
+
+            # convert computer to AiiDA node from its UUID
+            kwargs["computer"] = orm.load_computer(kwargs["computer"])
 
             # Checking if the code with this name already exists
             qb = orm.QueryBuilder()
@@ -1112,7 +1115,7 @@ class AiidaCodeSetup(ipw.VBox):
         self.label.value = ""
         self.computer.value = ""
         self.description.value = ""
-        self.remote_abs_path.value = ""
+        self.filepath_executable.value = ""
         self.use_double_quotes.value = False
         self.prepend_text.value = ""
         self.append_text.value = ""

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -13,6 +13,7 @@ import traitlets
 from aiida import common, orm, plugins
 from aiida.orm.utils.builders.computer import ComputerBuilder
 from aiida.transports.plugins.ssh import parse_sshconfig
+from aiida.common.exceptions import NotExistent
 from humanfriendly import InvalidSize, parse_size
 from IPython.display import clear_output, display
 
@@ -1131,6 +1132,17 @@ class AiidaCodeSetup(ipw.VBox):
                         getattr(self, key).label = value
                     except traitlets.TraitError:
                         self.message = f"Input plugin {value} is not installed."
+                elif key == "computer":
+                    # check if the computer is set by load the label.
+                    # if the computer not set put the value to None as placeholder for
+                    # ComputerDropdownWidget it will refresh after the computer set up.
+                    # if the computer is set pass the UUID to ComputerDropdownWdiget.
+                    try:
+                        computer = orm.load_computer(value)
+                    except NotExistent:
+                        getattr(self, key).value = None
+                    else:
+                        getattr(self, key).value = computer.uuid
                 else:
                     getattr(self, key).value = value
 

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -46,7 +46,7 @@ class ComputationalResourcesWidget(ipw.VBox):
     codes = traitlets.Dict(allow_none=True)
     allow_hidden_codes = traitlets.Bool(False)
     allow_disabled_computers = traitlets.Bool(False)
-    default_calc_job_plugin = traitlets.Unicode(allow_none=True)
+    input_plugin = traitlets.Unicode(allow_none=True)
 
     def __init__(self, description="Select code:", path_to_root="../", **kwargs):
         """Dropdown for Codes for one input plugin.
@@ -82,7 +82,7 @@ class ComputationalResourcesWidget(ipw.VBox):
 
         # Setting up codes and computers.
         self.comp_resources_database = ComputationalResourcesDatabaseWidget(
-            default_calc_job_plugin=self.default_calc_job_plugin
+            input_plugin=self.input_plugin
         )
 
         self.ssh_computer_setup = SshComputerSetup()
@@ -166,7 +166,7 @@ class ComputationalResourcesWidget(ipw.VBox):
             for c in orm.QueryBuilder()
             .append(
                 orm.Code,
-                filters={"attributes.input_plugin": self.default_calc_job_plugin},
+                filters={"attributes.input_plugin": self.input_plugin},
             )
             .all()
             if c[0].computer.is_user_configured(user)
@@ -188,7 +188,9 @@ class ComputationalResourcesWidget(ipw.VBox):
         with self.hold_trait_notifications():
             self.code_select_dropdown.options = self._get_codes()
             if not self.code_select_dropdown.options:
-                self.output.value = f"No codes found for default calcjob plugin '{self.default_calc_job_plugin}'."
+                self.output.value = (
+                    f"No codes found for input plugin '{self.input_plugin}'."
+                )
                 self.code_select_dropdown.disabled = True
             else:
                 self.code_select_dropdown.disabled = False
@@ -981,7 +983,7 @@ class AiidaCodeSetup(ipw.VBox):
         )
 
         # Code plugin.
-        self.default_calc_job_plugin = ipw.Dropdown(
+        self.input_plugin = ipw.Dropdown(
             options=sorted(
                 (ep.name, ep.name)
                 for ep in plugins.entry_point.get_entry_points("aiida.calculations")
@@ -999,7 +1001,7 @@ class AiidaCodeSetup(ipw.VBox):
             style=STYLE,
         )
 
-        self.filepath_executable = ipw.Text(
+        self.remote_abs_path = ipw.Text(
             placeholder="/path/to/executable",
             description="Absolute path to executable:",
             layout=LAYOUT,
@@ -1031,9 +1033,9 @@ class AiidaCodeSetup(ipw.VBox):
         children = [
             self.label,
             self.computer,
-            self.default_calc_job_plugin,
+            self.input_plugin,
             self.description,
-            self.filepath_executable,
+            self.remote_abs_path,
             self.use_double_quotes,
             self.prepend_text,
             self.append_text,
@@ -1042,10 +1044,10 @@ class AiidaCodeSetup(ipw.VBox):
         ]
         super().__init__(children, **kwargs)
 
-    @traitlets.validate("default_calc_job_plugin")
-    def _validate_default_calc_job_plugin(self, proposal):
+    @traitlets.validate("input_plugin")
+    def _validate_input_plugin(self, proposal):
         plugin = proposal["value"]
-        return plugin if plugin in self.default_calc_job_plugin.options else None
+        return plugin if plugin in self.input_plugin.options else None
 
     def on_setup_code(self, _=None):
         """Setup an AiiDA code."""
@@ -1068,9 +1070,6 @@ class AiidaCodeSetup(ipw.VBox):
             ]
 
             kwargs = {key: getattr(self, key).value for key in items_to_configure}
-
-            # convert computer to AiiDA node from its UUID
-            kwargs["computer"] = orm.load_computer(kwargs["computer"])
 
             # Checking if the code with this name already exists
             qb = orm.QueryBuilder()
@@ -1115,7 +1114,7 @@ class AiidaCodeSetup(ipw.VBox):
         self.label.value = ""
         self.computer.value = ""
         self.description.value = ""
-        self.filepath_executable.value = ""
+        self.remote_abs_path.value = ""
         self.use_double_quotes.value = False
         self.prepend_text.value = ""
         self.append_text.value = ""
@@ -1131,7 +1130,7 @@ class AiidaCodeSetup(ipw.VBox):
             self._reset()
         for key, value in self.code_setup.items():
             if hasattr(self, key):
-                if key == "default_calc_job_plugin":
+                if key == "input_plugin":
                     try:
                         getattr(self, key).label = value
                     except traitlets.TraitError:

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -205,7 +205,7 @@ class OptimadeQueryWidget(ipw.VBox):
 class ComputationalResourcesDatabaseWidget(ipw.VBox):
     """Extract the setup of a known computer from the AiiDA code registry."""
 
-    default_calc_job_plugin = traitlets.Unicode(allow_none=True)
+    input_plugin = traitlets.Unicode(allow_none=True)
     ssh_config = traitlets.Dict()
     computer_setup = traitlets.Dict()
     code_setup = traitlets.Dict()
@@ -261,10 +261,7 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
                     database[domain][computer].keys()
                     - {"computer-configure", "computer-setup"}
                 ):
-                    if (
-                        plugin
-                        != database[domain][computer][code]["default_calc_job_plugin"]
-                    ):
+                    if plugin != database[domain][computer][code]["input_plugin"]:
                         del database[domain][computer][code]
                 # If no codes remained that correspond to the chosen plugin, remove the computer.
                 if (
@@ -287,11 +284,11 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
 
     def update(self, _=None):
         database = requests.get(
-            "https://unkcpz.github.io/aiida-code-registry/database_v2_1.json"
+            "https://aiidateam.github.io/aiida-code-registry/database_v2.json"
         ).json()
         self.database = (
-            self.clean_up_database(database, self.default_calc_job_plugin)
-            if self.default_calc_job_plugin
+            self.clean_up_database(database, self.input_plugin)
+            if self.input_plugin
             else database
         )
 
@@ -378,6 +375,6 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
 
             self.code_setup = code_setup
 
-    @default("default_calc_job_plugin")
-    def _default_calc_job_plugin(self):
+    @default("input_plugin")
+    def _default_input_plugin(self):
         return None

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -284,7 +284,7 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
 
     def update(self, _=None):
         database = requests.get(
-            "https://aiidateam.github.io/aiida-code-registry/database_v2.json"
+            "https://unkcpz.github.io/aiida-code-registry/database_v2_1.json"
         ).json()
         self.database = (
             self.clean_up_database(database, self.input_plugin)

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -205,7 +205,7 @@ class OptimadeQueryWidget(ipw.VBox):
 class ComputationalResourcesDatabaseWidget(ipw.VBox):
     """Extract the setup of a known computer from the AiiDA code registry."""
 
-    input_plugin = traitlets.Unicode(allow_none=True)
+    default_calc_job_plugin = traitlets.Unicode(allow_none=True)
     ssh_config = traitlets.Dict()
     computer_setup = traitlets.Dict()
     code_setup = traitlets.Dict()
@@ -261,7 +261,10 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
                     database[domain][computer].keys()
                     - {"computer-configure", "computer-setup"}
                 ):
-                    if plugin != database[domain][computer][code]["input_plugin"]:
+                    if (
+                        plugin
+                        != database[domain][computer][code]["default_calc_job_plugin"]
+                    ):
                         del database[domain][computer][code]
                 # If no codes remained that correspond to the chosen plugin, remove the computer.
                 if (
@@ -287,8 +290,8 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
             "https://unkcpz.github.io/aiida-code-registry/database_v2_1.json"
         ).json()
         self.database = (
-            self.clean_up_database(database, self.input_plugin)
-            if self.input_plugin
+            self.clean_up_database(database, self.default_calc_job_plugin)
+            if self.default_calc_job_plugin
             else database
         )
 
@@ -375,6 +378,6 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
 
             self.code_setup = code_setup
 
-    @default("input_plugin")
-    def _default_input_plugin(self):
+    @default("default_calc_job_plugin")
+    def _default_calc_job_plugin(self):
         return None

--- a/notebooks/computational_resources.ipynb
+++ b/notebooks/computational_resources.ipynb
@@ -37,7 +37,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2cf5dc9d5f2645a38bafb0960c49ef8e",
+       "model_id": "4cd59b57f7d44a6f9d8ae237cbcdfbe2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resources = awb.ComputationalResourcesWidget(input_plugin='quantumespresso.pw')"
+    "resources = awb.ComputationalResourcesWidget(default_calc_job_plugin='quantumespresso.pw')"
    ]
   },
   {
@@ -70,7 +70,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3b7acf922b2a4530b976606efd2c688e",
+       "model_id": "2a9b9c557be1450fb10da2df406d4c48",
        "version_major": 2,
        "version_minor": 0
       },

--- a/notebooks/computational_resources.ipynb
+++ b/notebooks/computational_resources.ipynb
@@ -2,25 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "4013ce60",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
-       "    return false;\n",
-       "}\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -30,58 +15,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "53f49d32",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4cd59b57f7d44a6f9d8ae237cbcdfbe2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import aiidalab_widgets_base as awb"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "56116f88",
    "metadata": {},
    "outputs": [],
    "source": [
-    "resources = awb.ComputationalResourcesWidget(default_calc_job_plugin='quantumespresso.pw')"
+    "resources = awb.ComputationalResourcesWidget(input_plugin='quantumespresso.pw')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "b75b6687",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2a9b9c557be1450fb10da2df406d4c48",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "ComputationalResourcesWidget(children=(HBox(children=(Dropdown(description='Select code:', options={'pw-7.0@lo…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "display(resources)"
    ]

--- a/notebooks/computational_resources.ipynb
+++ b/notebooks/computational_resources.ipynb
@@ -2,10 +2,25 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "4013ce60",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
+       "    return false;\n",
+       "}\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%%javascript\n",
     "IPython.OutputArea.prototype._should_scroll = function(lines) {\n",
@@ -15,17 +30,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "53f49d32",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2cf5dc9d5f2645a38bafb0960c49ef8e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import aiidalab_widgets_base as awb"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "56116f88",
    "metadata": {},
    "outputs": [],
@@ -35,10 +63,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "b75b6687",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3b7acf922b2a4530b976606efd2c688e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ComputationalResourcesWidget(children=(HBox(children=(Dropdown(description='Select code:', options={'pw-7.0@lo…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "display(resources)"
    ]
@@ -46,7 +89,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -60,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
fixes #405 

The `ComputerDropdownWidget` is used in `AiidaCodeSetup` to set up the computer. It is fine if the computer is set pre-head and the dropdown widget can have the value of UUID. 
However, in "quick setup" of the code, we read from database and fill the computer widget and code setup widget. When it comes to the CopmuterDropdownWidget, the UUID is expected but the UUID is not ready.

We fix the issue by adding a check in when read the `code_setup` from database, if the computer is already set, the uuid is set for the value of `ComputerDropdownWidget`. Otherwise, we set the value of dropdown widget `None` to suppress the exception and in the quick setup process, it will first set up the computer, and after the computer is set, the `ComputerDropdownWidget` will refresh and the code_setup phase will run again to set the computer.
