### PR TITLE
Add screenshot teardown fixture - approach 1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,14 +91,15 @@ def selenium_driver(selenium, notebook_service):
 
 
 @pytest.fixture
-def screenshot(selenium, screenshot_dir):
-    """Take screenshot at the end of a selenium test,
-    regardless whether it succeeded or not."""
-    ctx = {"name": ""}
-    yield ctx
-    if not ctx["name"]:
-        raise ValueError("Empty the screenshot filename")  # noqa: TC003
-    selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
+def final_screenshot(request, screenshot_dir, selenium):
+    """Take screenshot at the end of the test.
+    Screenshot name is generated from the test function name
+    by stripping the 'test_' prefix
+    """
+    screenshot_name = f"{request.function.__name__[5:]}.png"
+    screenshot_path = Path.joinpath(screenshot_dir, screenshot_name)
+    yield
+    selenium.get_screenshot_as_file(screenshot_path)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,17 @@ def selenium_driver(selenium, notebook_service):
 
 
 @pytest.fixture
+def screenshot(selenium, screenshot_dir):
+    """Take screenshot at the end of a selenium test,
+    regardless whether it succeeded or not."""
+    ctx = {"name": ""}
+    yield ctx
+    if not ctx["name"]:
+        raise ValueError("Empty the screenshot filename")  # noqa: TC003
+    selenium.get_screenshot_as_file(f"{screenshot_dir}/{ctx['name']}")
+
+
+@pytest.fixture
 def firefox_options(firefox_options):
     firefox_options.add_argument("--headless")
     return firefox_options

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,49 +10,49 @@ def test_notebook_service_available(notebook_service):
     assert response.status_code == 200
 
 
-def test_process_list(selenium_driver, screenshot_dir):
+def test_process_list(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/process_list.ipynb")
+    screenshot["name"] = "process-list.png"
     driver.find_element(By.XPATH, '//button[text()="Update now"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/process-list.png")
 
 
-def test_aiida_datatypes_viewers(selenium_driver, screenshot_dir):
+def test_aiida_datatypes_viewers(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/aiida_datatypes_viewers.ipynb")
+    screenshot["name"] = "datatypes-viewer.png"
     driver.set_window_size(1000, 2000)
     driver.find_element(By.CLASS_NAME, "widget-label")
     driver.find_element(By.XPATH, '//button[text()="Clear selection"]')
     time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/datatypes-viewer.png")
 
 
-def test_eln_configure(selenium_driver, screenshot_dir):
+def test_eln_configure(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/eln_configure.ipynb")
+    screenshot["name"] = "eln-configure.png"
     driver.find_element(By.XPATH, '//button[text()="Set as default"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/eln-configure.png")
 
 
-def test_process(selenium_driver, screenshot_dir):
+def test_process(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/process.ipynb")
+    screenshot["name"] = "process.png"
     driver.find_element(By.XPATH, '//label[@title="Select calculation:"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/process.png")
 
 
-def test_wizard_apps(selenium_driver, screenshot_dir):
+def test_wizard_apps(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/wizard_apps.ipynb")
+    screenshot["name"] = "wizzard-apps.png"
     driver.find_element(By.XPATH, '//label[@title="Delivery progress:"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/wizzard-apps.png")
 
 
-def test_structures(selenium_driver, screenshot_dir):
+def test_structures(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/structures.ipynb")
+    screenshot["name"] = "structures.png"
     driver.set_window_size(1000, 900)
     driver.find_element(By.XPATH, '//button[text()="Upload Structure (0)"]')
-    time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/structures.png")
 
 
-def test_structures_generate_from_smiles(selenium_driver, screenshot_dir):
+def test_structures_generate_from_smiles(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/structures.ipynb")
+    screenshot["name"] = "structures_generate_from_smiles.png"
     driver.set_window_size(1000, 900)
     # Switch to SMILES tab in StructureManagerWidget
     driver.find_element(By.XPATH, "//*[text()='SMILES']").click()
@@ -69,29 +69,25 @@ def test_structures_generate_from_smiles(selenium_driver, screenshot_dir):
     ).send_keys("1")
     driver.find_element(By.XPATH, '//button[text()="Apply selection"]').click()
     driver.find_element(By.XPATH, "//div[starts-with(text(),'Id: 1; Symbol: C;')]")
-    driver.get_screenshot_as_file(
-        f"{screenshot_dir}/structures_generate_from_smiles_2.png"
-    )
 
 
-def test_eln_import(selenium_driver, screenshot_dir):
+def test_eln_import(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/eln_import.ipynb")
+    screenshot["name"] = "eln_import.png"
     # TODO: This find_element is not specific enough it seems,
     # on the screenshot the page is still loading.
     driver.find_element(By.ID, "tooltip")
     time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/eln-import.png")
 
 
-def test_computational_resources_code_setup(
-    selenium_driver, aiidalab_exec, screenshot_dir
-):
+def test_computational_resources_code_setup(selenium_driver, aiidalab_exec, screenshot):
     """Test the quicksetup of the code"""
     # check the code pw-7.0 is not in code list
     output = aiidalab_exec("verdi code list").decode().strip()
     assert "pw-7.0" not in output
 
     driver = selenium_driver("notebooks/computational_resources.ipynb")
+    screenshot["name"] = "computational-resources.png"
     driver.set_window_size(800, 800)
 
     # click the "Setup new code" button
@@ -147,6 +143,3 @@ def test_computational_resources_code_setup(
     # check the new code pw-7.0@daint-mc is in code list
     output = aiidalab_exec("verdi code list").decode().strip()
     assert "dos-7.0@daint-mc" in output
-
-    # take screenshots
-    driver.get_screenshot_as_file(f"{screenshot_dir}/computational-resources.png")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,15 +1,7 @@
 import time
 
-import pytest
 import requests
 from selenium.webdriver.common.by import By
-
-
-@pytest.mark.xfail
-def test_final_screenshot_fixture(notebook_service, final_screenshot):
-    """The final_screenshot teardown fixture
-    should produce a screenshot even for a failing test"""
-    raise ValueError()
 
 
 def test_notebook_service_available(notebook_service):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,7 +1,15 @@
 import time
 
+import pytest
 import requests
 from selenium.webdriver.common.by import By
+
+
+@pytest.mark.xfail
+def test_final_screenshot_fixture(notebook_service, final_screenshot):
+    """The final_screenshot teardown fixture
+    should produce a screenshot even for a failing test"""
+    raise ValueError()
 
 
 def test_notebook_service_available(notebook_service):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -13,7 +13,7 @@ def test_notebook_service_available(notebook_service):
 def test_process_list(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/process_list.ipynb")
     screenshot["name"] = "process-list.png"
-    driver.find_element(By.XPATH, '//button[text()="invalid button"]')
+    driver.find_element(By.XPATH, '//button[text()="Update now"]')
 
 
 def test_aiida_datatypes_viewers(selenium_driver, screenshot):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,49 +10,42 @@ def test_notebook_service_available(notebook_service):
     assert response.status_code == 200
 
 
-def test_process_list(selenium_driver, screenshot):
+def test_process_list(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/process_list.ipynb")
-    screenshot["name"] = "process-list.png"
     driver.find_element(By.XPATH, '//button[text()="Update now"]')
 
 
-def test_aiida_datatypes_viewers(selenium_driver, screenshot):
+def test_aiida_datatypes_viewers(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/aiida_datatypes_viewers.ipynb")
-    screenshot["name"] = "datatypes-viewer.png"
     driver.set_window_size(1000, 2000)
     driver.find_element(By.CLASS_NAME, "widget-label")
     driver.find_element(By.XPATH, '//button[text()="Clear selection"]')
     time.sleep(5)
 
 
-def test_eln_configure(selenium_driver, screenshot):
+def test_eln_configure(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/eln_configure.ipynb")
-    screenshot["name"] = "eln-configure.png"
     driver.find_element(By.XPATH, '//button[text()="Set as default"]')
 
 
-def test_process(selenium_driver, screenshot):
+def test_process(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/process.ipynb")
-    screenshot["name"] = "process.png"
     driver.find_element(By.XPATH, '//label[@title="Select calculation:"]')
 
 
-def test_wizard_apps(selenium_driver, screenshot):
+def test_wizard_apps(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/wizard_apps.ipynb")
-    screenshot["name"] = "wizzard-apps.png"
     driver.find_element(By.XPATH, '//label[@title="Delivery progress:"]')
 
 
-def test_structures(selenium_driver, screenshot):
+def test_structures(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/structures.ipynb")
-    screenshot["name"] = "structures.png"
     driver.set_window_size(1000, 900)
     driver.find_element(By.XPATH, '//button[text()="Upload Structure (0)"]')
 
 
-def test_structures_generate_from_smiles(selenium_driver, screenshot):
+def test_structures_generate_from_smiles(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/structures.ipynb")
-    screenshot["name"] = "structures_generate_from_smiles.png"
     driver.set_window_size(1000, 900)
     # Switch to SMILES tab in StructureManagerWidget
     driver.find_element(By.XPATH, "//*[text()='SMILES']").click()
@@ -71,23 +64,23 @@ def test_structures_generate_from_smiles(selenium_driver, screenshot):
     driver.find_element(By.XPATH, "//div[starts-with(text(),'Id: 1; Symbol: C;')]")
 
 
-def test_eln_import(selenium_driver, screenshot):
+def test_eln_import(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/eln_import.ipynb")
-    screenshot["name"] = "eln_import.png"
     # TODO: This find_element is not specific enough it seems,
     # on the screenshot the page is still loading.
     driver.find_element(By.ID, "tooltip")
     time.sleep(5)
 
 
-def test_computational_resources_code_setup(selenium_driver, aiidalab_exec, screenshot):
+def test_computational_resources_code_setup(
+    selenium_driver, aiidalab_exec, final_screenshot
+):
     """Test the quicksetup of the code"""
     # check the code pw-7.0 is not in code list
     output = aiidalab_exec("verdi code list").decode().strip()
     assert "pw-7.0" not in output
 
     driver = selenium_driver("notebooks/computational_resources.ipynb")
-    screenshot["name"] = "computational-resources.png"
     driver.set_window_size(800, 800)
 
     # click the "Setup new code" button

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -13,7 +13,7 @@ def test_notebook_service_available(notebook_service):
 def test_process_list(selenium_driver, screenshot):
     driver = selenium_driver("notebooks/process_list.ipynb")
     screenshot["name"] = "process-list.png"
-    driver.find_element(By.XPATH, '//button[text()="Update now"]')
+    driver.find_element(By.XPATH, '//button[text()="invalid button"]')
 
 
 def test_aiida_datatypes_viewers(selenium_driver, screenshot):


### PR DESCRIPTION
We want to take a screenshot at the end of each selenium test, even if (and especially) when the test fails.
So essentially we need to take the screenshot as part of the test teardown. Here's the relevant section of the pytest docs

https://docs.pytest.org/en/6.2.x/fixture.html#teardown-cleanup-aka-fixture-finalization

Our case is complicated by the fact that we somehow need to pass the screenshot name to the teardown method.
Here's the relevant section in docs and two SO questions were helpful:

https://docs.pytest.org/en/6.2.x/fixture.html#fixtures-can-introspect-the-requesting-test-context
https://stackoverflow.com/questions/58549670/pass-a-parameter-to-a-pytest-fixture-for-teardown

https://stackoverflow.com/questions/38488571/attributeerror-when-using-request-function-in-pytest-yield-fixture

In this PR, we take the approach of having a separate yield fixture. We pass the screenshot filename as a parameter to a dictionary object that is yielded by the fixture. Still feels a bit hacky, but it is quite clean and compact.

I'll also submit an PR with an alternative solution, where we extend the existing `selenium_driver` fixture.

Closes #419