### PR TITLE
Tests: Get screenshot at test teardown - approach 2

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,9 +67,13 @@ def notebook_service(docker_ip, docker_services, aiidalab_exec):
 
 
 @pytest.fixture(scope="function")
-def selenium_driver(selenium, notebook_service):
-    def _selenium_driver(nb_path):
+def selenium_driver(selenium, notebook_service, screenshot_dir):
+    final_screenshot_name = None
+
+    def _selenium_driver(nb_path, wait_time=5.0, screenshot_name=None):
         url, token = notebook_service
+        nonlocal final_screenshot_name
+        final_screenshot_name = screenshot_name
         url_with_token = urljoin(
             url, f"apps/apps/aiidalab-widgets-base/{nb_path}?token={token}"
         )
@@ -87,7 +91,9 @@ def selenium_driver(selenium, notebook_service):
 
         return selenium
 
-    return _selenium_driver
+    yield _selenium_driver
+    if final_screenshot_name:
+        selenium.get_screenshot_as_file(f"{screenshot_dir}/{final_screenshot_name}")
 
 
 @pytest.fixture

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -59,7 +59,7 @@ def test_structures(selenium_driver):
 def test_structures_generate_from_smiles(selenium_driver):
     driver = selenium_driver(
         "notebooks/structures.ipynb",
-        screenshot_name="structures_generate_from_smiles_2.png",
+        screenshot_name="structures_generate_from_smiles.png",
     )
     driver.set_window_size(1000, 900)
     # Switch to SMILES tab in StructureManagerWidget

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -10,49 +10,57 @@ def test_notebook_service_available(notebook_service):
     assert response.status_code == 200
 
 
-def test_process_list(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/process_list.ipynb")
+def test_process_list(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/process_list.ipynb", screenshot_name="process-list.png"
+    )
     driver.find_element(By.XPATH, '//button[text()="Update now"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/process-list.png")
 
 
-def test_aiida_datatypes_viewers(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/aiida_datatypes_viewers.ipynb")
+def test_aiida_datatypes_viewers(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/aiida_datatypes_viewers.ipynb",
+        screenshot_name="datatypes-viewer.png",
+    )
     driver.set_window_size(1000, 2000)
     driver.find_element(By.CLASS_NAME, "widget-label")
     driver.find_element(By.XPATH, '//button[text()="Clear selection"]')
     time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/datatypes-viewer.png")
 
 
-def test_eln_configure(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/eln_configure.ipynb")
+def test_eln_configure(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/eln_configure.ipynb", screenshot_name="eln-configure.png"
+    )
     driver.find_element(By.XPATH, '//button[text()="Set as default"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/eln-configure.png")
 
 
-def test_process(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/process.ipynb")
+def test_process(selenium_driver):
+    driver = selenium_driver("notebooks/process.ipynb", screenshot_name="process.png")
     driver.find_element(By.XPATH, '//label[@title="Select calculation:"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/process.png")
 
 
-def test_wizard_apps(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/wizard_apps.ipynb")
+def test_wizard_apps(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/wizard_apps.ipynb", screenshot_name="wizzard-apps.png"
+    )
     driver.find_element(By.XPATH, '//label[@title="Delivery progress:"]')
-    driver.get_screenshot_as_file(f"{screenshot_dir}/wizzard-apps.png")
 
 
-def test_structures(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/structures.ipynb")
+def test_structures(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/structures.ipynb", screenshot_name="structures.png"
+    )
     driver.set_window_size(1000, 900)
     driver.find_element(By.XPATH, '//button[text()="Upload Structure (0)"]')
     time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/structures.png")
 
 
-def test_structures_generate_from_smiles(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/structures.ipynb")
+def test_structures_generate_from_smiles(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/structures.ipynb",
+        screenshot_name="structures_generate_from_smiles_2.png",
+    )
     driver.set_window_size(1000, 900)
     # Switch to SMILES tab in StructureManagerWidget
     driver.find_element(By.XPATH, "//*[text()='SMILES']").click()
@@ -69,29 +77,28 @@ def test_structures_generate_from_smiles(selenium_driver, screenshot_dir):
     ).send_keys("1")
     driver.find_element(By.XPATH, '//button[text()="Apply selection"]').click()
     driver.find_element(By.XPATH, "//div[starts-with(text(),'Id: 1; Symbol: C;')]")
-    driver.get_screenshot_as_file(
-        f"{screenshot_dir}/structures_generate_from_smiles_2.png"
+
+
+def test_eln_import(selenium_driver):
+    driver = selenium_driver(
+        "notebooks/eln_import.ipynb", screenshot_name="eln-import.png"
     )
-
-
-def test_eln_import(selenium_driver, screenshot_dir):
-    driver = selenium_driver("notebooks/eln_import.ipynb")
     # TODO: This find_element is not specific enough it seems,
     # on the screenshot the page is still loading.
     driver.find_element(By.ID, "tooltip")
     time.sleep(5)
-    driver.get_screenshot_as_file(f"{screenshot_dir}/eln-import.png")
 
 
-def test_computational_resources_code_setup(
-    selenium_driver, aiidalab_exec, screenshot_dir
-):
+def test_computational_resources_code_setup(selenium_driver, aiidalab_exec):
     """Test the quicksetup of the code"""
     # check the code pw-7.0 is not in code list
     output = aiidalab_exec("verdi code list").decode().strip()
     assert "pw-7.0" not in output
 
-    driver = selenium_driver("notebooks/computational_resources.ipynb")
+    driver = selenium_driver(
+        "notebooks/computational_resources.ipynb",
+        screenshot_name="computational-resources.png",
+    )
     driver.set_window_size(800, 800)
 
     # click the "Setup new code" button
@@ -147,6 +154,3 @@ def test_computational_resources_code_setup(
     # check the new code pw-7.0@daint-mc is in code list
     output = aiidalab_exec("verdi code list").decode().strip()
     assert "dos-7.0@daint-mc" in output
-
-    # take screenshots
-    driver.get_screenshot_as_file(f"{screenshot_dir}/computational-resources.png")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -14,7 +14,7 @@ def test_process_list(selenium_driver):
     driver = selenium_driver(
         "notebooks/process_list.ipynb", screenshot_name="process-list.png"
     )
-    driver.find_element(By.XPATH, '//button[text()="Update now"]')
+    driver.find_element(By.XPATH, '//button[text()="invalid button"]')
 
 
 def test_aiida_datatypes_viewers(selenium_driver):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -14,7 +14,7 @@ def test_process_list(selenium_driver):
     driver = selenium_driver(
         "notebooks/process_list.ipynb", screenshot_name="process-list.png"
     )
-    driver.find_element(By.XPATH, '//button[text()="invalid button"]')
+    driver.find_element(By.XPATH, '//button[text()="Update now"]')
 
 
 def test_aiida_datatypes_viewers(selenium_driver):


### PR DESCRIPTION
This is an alternative PR to #421, see that PR for a detailed problem description. These two PRs should be reviewed together and it should be decided which approach is preferred. 

Here to take a final screenshot, we modify the existing `selenium_driver` fixture. Screenshot name is passed in as an optional parameter when getting the driver.

I don't have a strong preference. I think a like the approach in #421 (having a dedicated new screenshot fixture) a bit more, because `selenium_driver` fixture is already quite busy and here we're making it more complicated. 

Closes #419