### PR TITLE
CI: Configure pre-commit schedule to run quarterly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+ci:
+    autoupdate_schedule: quarterly
+
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.4.0


### PR DESCRIPTION
I find the constant barrage of pre-commit PRs from various repos distracting / annoying, and not particularly useful. I'd propose to run them only quarterly, as was already done in a couple of repositories, such as `aiidalab-launch` and `aiidalab-docker-stack`. WDYT? If you agree I'll do the same change for `aiidalab` and `aiidalab-home` repos as those are the ones I am currently subscribed to.

https://github.com/aiidalab/aiidalab-launch/pull/143