### PR TITLE
process followers widget need interface updated

### DIFF
--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -243,7 +243,7 @@ class ProcessFollowerWidget(ipw.VBox):
         """Initiate all the followers."""
         self._monitor = None
 
-        self.value = process.uuid
+        self.value = process.uuid if process else None
         self._run_after_completed = []
         self.update_interval = update_interval
         self.followers = []

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -67,7 +67,9 @@ def viewer(obj, downloadable=True, **kwargs):
 
     Returns the object itself if the viewer wasn't found."""
     if not isinstance(obj, Node):  # only working with AiiDA nodes
-        warnings.warn(f"This viewer works only with AiiDA objects, got {type(obj)}")
+        warnings.warn(
+            f"This viewer works only with AiiDA objects, got {type(obj)}", stacklevel=2
+        )
         return obj
 
     try:
@@ -76,7 +78,8 @@ def viewer(obj, downloadable=True, **kwargs):
         if obj.node_type in str(exc):
             warnings.warn(
                 "Did not find an appropriate viewer for the {} object. Returning the object "
-                "itself.".format(type(obj))
+                "itself.".format(type(obj)),
+                stacklevel=2,
             )
             return obj
         raise
@@ -206,6 +209,7 @@ class _StructureDataBaseViewer(ipw.VBox):
             warnings.warn(
                 "`configure_view` is deprecated, please use `configuration_tabs` instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             if not configure_view:
                 configuration_tabs.clear()

--- a/notebooks/process.ipynb
+++ b/notebooks/process.ipynb
@@ -29,6 +29,7 @@
     "import ipywidgets as ipw\n",
     "from IPython.display import clear_output\n",
     "from aiida.cmdline.utils.ascii_vis import format_call_graph\n",
+    "from aiida.orm import load_node\n",
     "import urllib.parse as urlparse\n",
     "from aiidalab_widgets_base import ProcessFollowerWidget, ProgressBarWidget, ProcessReportWidget\n",
     "from aiidalab_widgets_base import ProcessInputsWidget, ProcessOutputsWidget, ProcessCallStackWidget, RunningCalcJobOutputWidget"


### PR DESCRIPTION
When running `process.ipynb` with a real process, the exception raised that the interface calling `ProcessMonitorWidget` is incorrect.
I update the `ProcessFollowerWidget` interface to use the `value` for process uuid as well. 
This brings the issue https://github.com/aiidalab/aiidalab-widgets-base/issues/426 to more higher priority that we what having all such widget have a new interface which is more designable in my opinion. 
