### PR TITLE
pin the widgetsnbextension version < 3.6.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     humanfriendly~=10.0
     ipytree~=0.2
     ipywidgets~=7.7
-    widgetsnbextension~=3.6,<3.6.3
+    widgetsnbextension<3.6.3
     more-itertools~=8.0
     pymysql~=0.9
     nglview~=3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     humanfriendly~=10.0
     ipytree~=0.2
     ipywidgets~=7.7
+    widgetsnbextension~=3.6,<3.6.3
     more-itertools~=8.0
     pymysql~=0.9
     nglview~=3.0


### PR DESCRIPTION
`widgetsnbextension==3.6.3` which was released (in https://github.com/jupyter-widgets/ipywidgets/commit/5d9f6488235d480b42d4380532804121504e9c93) on 21st Mar break the `ProcessNodeTree` widget.