### PR TITLE
use aiida_structuredata as transition state of query

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -191,8 +191,7 @@ class OptimadeQueryWidget(ipw.VBox):
 
     def _update_structure(self, change: dict) -> None:
         """New structure chosen"""
-        self.structure = change["new"].as_ase if change["new"] else None
-
+        self.structure = change["new"].as_aiida_structuredata.get_ase() if change["new"] else None
 
 class ComputationalResourcesDatabaseWidget(ipw.VBox):
     """Extract the setup of a known computer from the AiiDA code registry."""

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -191,7 +191,10 @@ class OptimadeQueryWidget(ipw.VBox):
 
     def _update_structure(self, change: dict) -> None:
         """New structure chosen"""
-        self.structure = change["new"].as_aiida_structuredata.get_ase() if change["new"] else None
+        self.structure = (
+            change["new"].as_aiida_structuredata.get_ase() if change["new"] else None
+        )
+
 
 class ComputationalResourcesDatabaseWidget(ipw.VBox):
     """Extract the setup of a known computer from the AiiDA code registry."""


### PR DESCRIPTION
Using aiida structuredata type will give us more flexibility and control to the structure results get from query. 
The queryed OPTIMADE structure will -> aiida structuredata -> ase Atoms. 
The ASE structure as the trait of the widget because we want to use its versatile converter. 
It can also be fixed by https://github.com/Materials-Consortia/optimade-python-tools/pull/1570 but we need then bump optimade-client and then aiidalab widget base. 
Meanwhile, the optimade structure to aiida_structuredata is more robust and versatile to support such as the partially occupied sites. 