### PR TITLE
New Feature : Editor Adding tags to structure

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -25,6 +25,7 @@ from .process import (
     SubmitButtonWidget,
 )
 from .structures import (
+    AddingTagsEditor,
     BasicCellEditor,
     BasicStructureEditor,
     SmilesWidget,
@@ -37,6 +38,7 @@ from .viewers import AiidaNodeViewWidget, register_viewer_widget, viewer
 from .wizard import WizardAppWidget, WizardAppWidgetStep
 
 __all__ = [
+    "AddingTagsEditor",
     "AiidaNodeViewWidget",
     "BasicStructureEditor",
     "BasicCellEditor",

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -17,8 +17,14 @@ from aiida import engine, orm, plugins
 
 # Local imports
 from .data import LigandSelectorWidget
-
-from .utils import StatusHTML, exceptions, get_ase_from_file, get_formula, string_range_to_list, list_to_string_range'
+from .utils import (
+    StatusHTML,
+    exceptions,
+    get_ase_from_file,
+    get_formula,
+    list_to_string_range,
+    string_range_to_list,
+)
 from .viewers import StructureDataViewer
 
 CifData = plugins.DataFactory("core.cif")

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -6,6 +6,7 @@ import io
 import pathlib
 import tempfile
 from collections import OrderedDict
+from copy import deepcopy
 
 import ase
 import ipywidgets as ipw
@@ -13,10 +14,11 @@ import numpy as np
 import spglib
 import traitlets as tl
 from aiida import engine, orm, plugins
-from copy import deepcopy
+
 # Local imports
 from .data import LigandSelectorWidget
-from .utils import StatusHTML, exceptions, get_ase_from_file, get_formula
+
+from .utils import StatusHTML, exceptions, get_ase_from_file, get_formula, string_range_to_list, list_to_string_range'
 from .viewers import StructureDataViewer
 
 CifData = plugins.DataFactory("core.cif")
@@ -1461,20 +1463,32 @@ class AddingTagsEditor(ipw.VBox):
         self.tag = ipw.BoundedIntText(
             description="Tag", value=1, min=0, max=4, layout={"width": "initial"}
         )
-        self.add_tags = ipw.Button(description="Update tags", button_style= 'primary', layout={"width": "initial"})
+        self.add_tags = ipw.Button(
+            description="Update tags",
+            button_style="primary",
+            layout={"width": "initial"},
+        )
         self.add_tags.on_click(self._add_tags)
-        self.clear_tags = ipw.Button(description="Clear tags", button_style= 'primary', layout={"width": "initial"})
-        self.clear_all_tags = ipw.Button(description="Clear all tags", button_style= 'primary', layout={"width": "initial"})
+        self.clear_tags = ipw.Button(
+            description="Clear tags",
+            button_style="primary",
+            layout={"width": "initial"},
+        )
+        self.clear_all_tags = ipw.Button(
+            description="Clear all tags",
+            button_style="primary",
+            layout={"width": "initial"},
+        )
         self.clear_tags.on_click(self._clear_tags)
         self.clear_all_tags.on_click(self._clear_all_tags)
         super().__init__(
-            children = [
+            children=[
                 ipw.HBox([self.atom_selection, self.from_selection, self.tag]),
                 ipw.HBox([self.add_tags, self.clear_tags, self.clear_all_tags]),
                 self._status_message,
-            ]   
+            ]
         )
-    
+
     def _from_selection(self, _=None):
         """Set the atom selection from the current selection."""
         self.atom_selection.value = list_to_string_range(self.selection)
@@ -1500,7 +1514,7 @@ class AddingTagsEditor(ipw.VBox):
             self.structure = deepcopy(new_structure)
             self.input_selection = None
             self.input_selection = deepcopy(self.selection)
-    
+
     def _clear_tags(self, _=None):
         """Clear tags from selected atoms."""
         if not self.atom_selection.value:


### PR DESCRIPTION
This PR implements a new Editor AddingTagsEditor

The idea behind the editor is to enable the user to set different kinds of atoms in a structure
The widget uses the ase.Atoms tags. 

The editor allows defining more kinds in a structure
for example, a structure can have Fe, O, and Fe1 (selected atoms)

This editor (or the idea behind it) is to enable the user to define new kinds, these new kinds can later be set to a specific magnetization for new kinds in the StructureData (For example in the AiiDAlab QE app).