### PR TITLE
Remove spinning Thread from WizzardAppWidgetStep

### DIFF
--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -188,11 +188,13 @@ class WizardAppWidget(ipw.VBox):
             self.accordion.children[idx] for idx in range(len(self.accordion.children))
         ]
 
-        if all(step.can_reset() for step in steps):
-            return True
+        if not all(step.can_reset() for step in steps):
+            return False
 
         if any(step.state is not WizardAppWidgetStep.State.INIT for step in steps):
             return True
+
+        return False
 
     def _update_buttons(self):
         with self.hold_trait_notifications():

--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -188,8 +188,8 @@ class WizardAppWidget(ipw.VBox):
             self.accordion.children[idx] for idx in range(len(self.accordion.children))
         ]
 
-        if any(not step.can_reset() for step in steps):
-            return False
+        if all(step.can_reset() for step in steps):
+            return True
 
         if any(step.state is not WizardAppWidgetStep.State.INIT for step in steps):
             return True

--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -5,8 +5,6 @@ Authors:
     * Carl Simon Adorf <simon.adorf@epfl.ch>
 """
 import enum
-import threading
-import time
 
 import ipywidgets as ipw
 import traitlets as tl
@@ -82,19 +80,10 @@ class WizardAppWidget(ipw.VBox):
         WizardAppWidgetStep.State.INIT: "\u25cb",
         WizardAppWidgetStep.State.READY: "\u25ce",
         WizardAppWidgetStep.State.CONFIGURED: "\u25cf",
-        WizardAppWidgetStep.State.ACTIVE: ["\u25dc", "\u25dd", "\u25de", "\u25df"],
+        WizardAppWidgetStep.State.ACTIVE: "\u231b",
         WizardAppWidgetStep.State.SUCCESS: "\u2713",
         WizardAppWidgetStep.State.FAIL: "\u00d7",
     }
-
-    @classmethod
-    def icons(cls):
-        """Return the icon set and return animated icons based on the current time stamp."""
-        t = time.time()
-        return {
-            key: item if isinstance(item, str) else item[int(t * len(item) % len(item))]
-            for key, item in cls.ICONS.items()
-        }
 
     selected_index = tl.Int(allow_none=True)
 
@@ -113,17 +102,6 @@ class WizardAppWidget(ipw.VBox):
         self.accordion = ipw.Accordion(children=widgets)
         self._update_titles()
         ipw.link((self.accordion, "selected_index"), (self, "selected_index"))
-
-        # Automatically update titles to implement the "spinner"
-
-        self._run_update_thread = True
-
-        def spinner_thread():
-            while self._run_update_thread:
-                time.sleep(0.1)
-                self._update_titles()
-
-        threading.Thread(target=spinner_thread).start()
 
         # Watch for changes to each step's state
         for widget in widgets:
@@ -171,7 +149,7 @@ class WizardAppWidget(ipw.VBox):
 
     def _update_titles(self):
         for i, (title, widget) in enumerate(zip(self.titles, self.accordion.children)):
-            icon = self.icons().get(widget.state, str(widget.state).upper())
+            icon = self.ICONS.get(widget.state, str(widget.state).upper())
             self.accordion.set_title(i, f"{icon} Step {i+1}: {title}")
 
     def _consider_auto_advance(self, _=None):

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -92,7 +92,7 @@ def test_wizard_app_widget():
     assert widget.accordion.get_title(1) == "○ Step 2: View results"
 
     # Check state after finishing the first step again.
-    s1.config = False  # This should trigger an attempt to advance to the next step.
+    s1.config = True  # This should trigger an attempt to advance to the next step.
     assert s1.state == s1.State.SUCCESS
     assert s2.state == s2.State.READY
     assert widget.accordion.selected_index == 1

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -84,6 +84,3 @@ def test_wizard_app_widget():
     assert s1.state == s1.State.SUCCESS
     widget.accordion.selected_index = None  # All steps are closed.
     s1.config = False  # This should trigger an attempt to advance to the next step.
-
-    # Stop the thread that is running the header update to let pytest finish.
-    widget._run_update_thread = False

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -115,6 +115,6 @@ def test_wizard_app_widget():
 
     # Click on the next button.
     widget.next_button.click()
-    assert widget.accordion.selected_index == 0
+    assert widget.accordion.selected_index == 1
     assert widget.next_button.disabled is True
     assert widget.back_button.disabled is False

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -37,6 +37,9 @@ def test_wizard_app_widget():
         def submit_order(self, _=None):
             pass
 
+        def reset(self):
+            pass
+
         @tl.default("config")
         def _default_config(self):
             return False
@@ -57,30 +60,51 @@ def test_wizard_app_widget():
             ("Setup", s1),
             ("View results", s2),
         ],
-        testing=True,
     )
 
     # Check initial state.
     assert s1.state == s1.State.INIT
     assert s2.state == s2.State.INIT
     assert widget.accordion.selected_index == 0
-
-    s1.order_button.click()
+    assert widget.next_button.disabled is True
+    assert widget.back_button.disabled is True
+    assert widget.accordion.get_title(0) == "○ Step 1: Setup"
+    assert widget.accordion.get_title(1) == "○ Step 2: View results"
+    assert widget.can_reset()
 
     # Check state after finishing the first step.
+    s1.order_button.click()
     assert s1.state == s1.State.SUCCESS
     assert s2.state == s2.State.READY
     assert widget.accordion.selected_index == 1
     assert widget.next_button.disabled is True
+    assert widget.back_button.disabled is False
+    assert widget.accordion.get_title(0) == "✓ Step 1: Setup"
+    assert widget.accordion.get_title(1) == "◎ Step 2: View results"
 
     # Check state after resetting the app.
-    widget.reset()
+    widget.reset_button.click()
     assert s1.state == s1.State.INIT
     assert s2.state == s2.State.INIT
     assert widget.back_button.disabled is True
+    assert widget.next_button.disabled is True
+    assert widget.accordion.get_title(0) == "○ Step 1: Setup"
+    assert widget.accordion.get_title(1) == "○ Step 2: View results"
 
     # Check state after finishing the first step again.
-    s1.order_button.click()
-    assert s1.state == s1.State.SUCCESS
-    widget.accordion.selected_index = None  # All steps are closed.
     s1.config = False  # This should trigger an attempt to advance to the next step.
+    assert s1.state == s1.State.SUCCESS
+    assert s2.state == s2.State.READY
+    assert widget.accordion.selected_index == 1
+    assert widget.next_button.disabled is True
+    assert widget.back_button.disabled is False
+    assert widget.accordion.get_title(0) == "✓ Step 1: Setup"
+    assert widget.accordion.get_title(1) == "◎ Step 2: View results"
+
+    # Click on the back button.
+    widget.back_button.click()
+    assert s1.state == s1.State.SUCCESS
+    assert s2.state == s2.State.READY
+    assert widget.accordion.selected_index == 0
+    assert widget.next_button.disabled is False
+    assert widget.back_button.disabled is True

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -70,7 +70,7 @@ def test_wizard_app_widget():
     assert widget.back_button.disabled is True
     assert widget.accordion.get_title(0) == "○ Step 1: Setup"
     assert widget.accordion.get_title(1) == "○ Step 2: View results"
-    assert widget.can_reset()
+    assert not widget.can_reset()
 
     # Check state after finishing the first step.
     s1.order_button.click()
@@ -81,6 +81,7 @@ def test_wizard_app_widget():
     assert widget.back_button.disabled is False
     assert widget.accordion.get_title(0) == "✓ Step 1: Setup"
     assert widget.accordion.get_title(1) == "◎ Step 2: View results"
+    assert widget.can_reset()
 
     # Check state after resetting the app.
     widget.reset_button.click()
@@ -90,6 +91,7 @@ def test_wizard_app_widget():
     assert widget.next_button.disabled is True
     assert widget.accordion.get_title(0) == "○ Step 1: Setup"
     assert widget.accordion.get_title(1) == "○ Step 2: View results"
+    assert not widget.can_reset()
 
     # Check state after finishing the first step again.
     s1.config = True  # This should trigger an attempt to advance to the next step.
@@ -100,6 +102,7 @@ def test_wizard_app_widget():
     assert widget.back_button.disabled is False
     assert widget.accordion.get_title(0) == "✓ Step 1: Setup"
     assert widget.accordion.get_title(1) == "◎ Step 2: View results"
+    assert widget.can_reset()
 
     # Click on the back button.
     widget.back_button.click()
@@ -108,3 +111,4 @@ def test_wizard_app_widget():
     assert widget.accordion.selected_index == 0
     assert widget.next_button.disabled is False
     assert widget.back_button.disabled is True
+    assert widget.can_reset()

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -112,3 +112,9 @@ def test_wizard_app_widget():
     assert widget.next_button.disabled is False
     assert widget.back_button.disabled is True
     assert widget.can_reset()
+
+    # Click on the next button.
+    widget.next_button.click()
+    assert widget.accordion.selected_index == 0
+    assert widget.next_button.disabled is True
+    assert widget.back_button.disabled is False


### PR DESCRIPTION
WizzardAppWidget uses an infinite background thread to continously update titles of the Accordion widget. It looks like the only reason for this is to implement a dynamic "spinner".
This thread just needlesly consumes server resources for a very little benefit. Implementing a "spinner" in this way is silly.

More importantly, it looks like this background thread is the main reason for the memory leak we're seeing, see https://github.com/aiidalab/issues/issues/13

Here I remove the thread in favour of a static unicode character, in line with all the other icons. It would be great if we could use some dynamic icons, e.g. fa-spinner as used in the SmilesWidget, but it looks like the Accordion.set_title() function does not parse HTML. Ultimately I think having static icon is fine, and users can implement something more dynamic in the child widgets.

TODO:
 - [x] Extend the existing unit test. Most importantly, we should test that the titles are updated when the `state` trait of the child widget changes.
 - [x] Is there a better Unicode character that we could use?