### PR TITLE
ProcessMonitor: Increase default timeout

### DIFF
--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -724,7 +724,7 @@ class ProcessMonitor(tl.HasTraits):
     def __init__(self, callbacks=None, on_sealed=None, timeout=None, **kwargs):
         self.callbacks = [] if callbacks is None else list(callbacks)
         self.on_sealed = [] if on_sealed is None else list(on_sealed)
-        self.timeout = 0.1 if timeout is None else timeout
+        self.timeout = 1.0 if timeout is None else timeout
 
         self._monitor_thread = None
         self._monitor_thread_stop = threading.Event()


### PR DESCRIPTION
ProcessMonitor has a background thread that polls the process status. The default interval is now 0.1 seconds which is quite aggressive, and may potentially lead to memory leak as discussed on https://github.com/aiidalab/issues/issue/13

Here I propose to increase the default to 1.0s, since the typical AiiDA workflow will anyway take quite a bit longer. If that seems to large, perhaps 0.5s might be a good compromise? In any case, widgets can override this by passing the timeout parameter to the constructor.