### PR TITLE
Remove leftover load profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,6 @@ name: continuous-integration
 
 on: [push, pull_request]
 
-# https://docs.github.com/en/actions/using-jobs/using-concurrency
-concurrency:
-    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ name: continuous-integration
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
     pre-commit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,8 @@ jobs:
               run: pip install -e .[dev,smiles]
 
             - name: Run pytest
-              run: pytest -v tests --cov
+              # use TESTING=true to disable the automatic load of the aiida profile
+              run: TESTING=true pytest -v tests --cov
               env:
                   TAG: ${{ matrix.tag }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,7 @@ jobs:
               run: pip install -e .[dev,smiles]
 
             - name: Run pytest
-              # use TESTING=true to disable the automatic load of the aiida profile
-              run: TESTING=true pytest -v tests --cov
+              run: pytest -v tests --cov
               env:
                   TAG: ${{ matrix.tag }}
 

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -15,13 +15,13 @@ load_profile();</pre>
 if get_profile() is None:
     # if no profile is loaded, load the default profile and raise a deprecation warning
     from aiida import load_profile
-    from IPython.display import display, HTML
-    
+    from IPython.display import HTML, display
+
     load_profile()
-    
+
     profile = get_profile()
     assert profile is not None, "Failed to load the default profile"
-    
+
     # raise a deprecation warning
     warning = HTML(_WARNING_TEMPLATE.format(profile=profile.name, version="v3.0.0"))
     display(warning)

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -1,6 +1,4 @@
 """Reusable widgets for AiiDAlab applications."""
-import os
-
 from aiida.manage import get_profile
 
 _WARNING_TEMPLATE = """
@@ -13,15 +11,25 @@ load_profile();</pre>
 </div>
 """
 
-# use the environment variable to control the automatic profile loading
-# so it can be disabled for testing, e.g. in the CI
-# use `TESTING=1 pytest` to disable the automatic profile loading
-TESTING = os.environ.get("TESTING", "False").lower() in ["true", "1"]
+
+# We only detect profile and throw a warning if it is on the notebook
+# It is not necessary to do this in the unit tests
+def is_running_in_jupyter():
+    try:
+        from IPython import get_ipython
+
+        if get_ipython() is not None:
+            return True
+        else:
+            return False
+    except NameError:
+        return False
+
 
 # load the default profile if no profile is loaded, and raise a deprecation warning
 # this is a temporary solution to avoid breaking existing notebooks
 # this will be removed in the next major release
-if not TESTING and get_profile() is None:
+if is_running_in_jupyter() and get_profile() is None:
     # if no profile is loaded, load the default profile and raise a deprecation warning
     from aiida import load_profile
     from IPython.display import HTML, display

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -1,4 +1,6 @@
 """Reusable widgets for AiiDAlab applications."""
+import os
+
 from aiida.manage import get_profile
 
 _WARNING_TEMPLATE = """
@@ -11,8 +13,15 @@ load_profile();</pre>
 </div>
 """
 
+# use the environment variable to control the automatic profile loading
+# so it can be disabled for testing, e.g. in the CI
+# use `TESTING=1 pytest` to disable the automatic profile loading
+TESTING = os.environ.get("TESTING", "False").lower() in ["true", "1"]
 
-if get_profile() is None:
+# load the default profile if no profile is loaded, and raise a deprecation warning
+# this is a temporary solution to avoid breaking existing notebooks
+# this will be removed in the next major release
+if not TESTING and get_profile() is None:
     # if no profile is loaded, load the default profile and raise a deprecation warning
     from aiida import load_profile
     from IPython.display import HTML, display

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -1,5 +1,4 @@
 """Reusable widgets for AiiDAlab applications."""
-
 from .computational_resources import (
     ComputationalResourcesWidget,
     ComputerDropdownWidget,

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -1,7 +1,4 @@
 """Reusable widgets for AiiDAlab applications."""
-from aiida import load_profile
-
-load_profile()
 
 from .computational_resources import (
     ComputationalResourcesWidget,

--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -1,4 +1,31 @@
 """Reusable widgets for AiiDAlab applications."""
+from aiida.manage import get_profile
+
+_WARNING_TEMPLATE = """
+<div style="background-color: #f7f7f7; border: 2px solid #e0e0e0; padding: 20px; border-radius: 5px;">
+    <p style="font-size: 16px; font-weight: bold; color: #ff5733;">Warning:</p>
+    <p style="font-size: 14px;">The default profile '<span style="font-style: italic;">{profile}</span>' was loaded automatically. This behavior will be removed in the <span style="font-style: italic;">{version}</span>. Please load the profile manually before loading modules from aiidalab-widgets-base by adding the following code at the beginning cell of the notebook:</p>
+    <pre style="background-color: #f0f0f0; padding: 10px; border: 1px solid #ccc; font-family: 'Courier New', monospace;">
+from aiida import load_profile
+load_profile();</pre>
+</div>
+"""
+
+
+if get_profile() is None:
+    # if no profile is loaded, load the default profile and raise a deprecation warning
+    from aiida import load_profile
+    from IPython.display import display, HTML
+    
+    load_profile()
+    
+    profile = get_profile()
+    assert profile is not None, "Failed to load the default profile"
+    
+    # raise a deprecation warning
+    warning = HTML(_WARNING_TEMPLATE.format(profile=profile.name, version="v3.0.0"))
+    display(warning)
+
 from .computational_resources import (
     ComputationalResourcesWidget,
     ComputerDropdownWidget,

--- a/notebooks/aiida_datatypes_viewers.ipynb
+++ b/notebooks/aiida_datatypes_viewers.ipynb
@@ -13,13 +13,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import io\n",
     "from os import path\n",
     "from aiida.plugins import DataFactory\n",
-    "from aiidalab_widgets_base import viewer\n",
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile()"
+    "from aiidalab_widgets_base import viewer"
    ]
   },
   {
@@ -232,7 +240,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -246,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/aiida_datatypes_viewers.ipynb
+++ b/notebooks/aiida_datatypes_viewers.ipynb
@@ -13,17 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile();"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import io\n",
     "from os import path\n",
     "from aiida.plugins import DataFactory\n",

--- a/notebooks/aiida_datatypes_viewers.ipynb
+++ b/notebooks/aiida_datatypes_viewers.ipynb
@@ -16,7 +16,10 @@
     "import io\n",
     "from os import path\n",
     "from aiida.plugins import DataFactory\n",
-    "from aiidalab_widgets_base import viewer"
+    "from aiidalab_widgets_base import viewer\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
    ]
   },
   {

--- a/notebooks/computational_resources.ipynb
+++ b/notebooks/computational_resources.ipynb
@@ -16,14 +16,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "864bd498",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "53f49d32",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import aiidalab_widgets_base as awb\n",
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile()"
+    "import aiidalab_widgets_base as awb"
    ]
   },
   {

--- a/notebooks/computational_resources.ipynb
+++ b/notebooks/computational_resources.ipynb
@@ -20,7 +20,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import aiidalab_widgets_base as awb"
+    "import aiidalab_widgets_base as awb\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
    ]
   },
   {

--- a/notebooks/eln_configure.ipynb
+++ b/notebooks/eln_configure.ipynb
@@ -26,6 +26,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cc68ce6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "celtic-norwegian",
    "metadata": {},
    "outputs": [],
@@ -60,7 +72,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/eln_import.ipynb
+++ b/notebooks/eln_import.ipynb
@@ -26,6 +26,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ea069627",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "celtic-norwegian",
    "metadata": {},
    "outputs": [],
@@ -117,7 +129,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/process.ipynb
+++ b/notebooks/process.ipynb
@@ -32,7 +32,10 @@
     "import urllib.parse as urlparse\n",
     "from aiida.orm import load_node\n",
     "from aiidalab_widgets_base import ProcessFollowerWidget, ProgressBarWidget, ProcessReportWidget\n",
-    "from aiidalab_widgets_base import ProcessInputsWidget, ProcessOutputsWidget, ProcessCallStackWidget, RunningCalcJobOutputWidget"
+    "from aiidalab_widgets_base import ProcessInputsWidget, ProcessOutputsWidget, ProcessCallStackWidget, RunningCalcJobOutputWidget\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
    ]
   },
   {

--- a/notebooks/process.ipynb
+++ b/notebooks/process.ipynb
@@ -26,16 +26,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ipywidgets as ipw\n",
     "from IPython.display import clear_output\n",
     "from aiida.cmdline.utils.ascii_vis import format_call_graph\n",
     "import urllib.parse as urlparse\n",
     "from aiida.orm import load_node\n",
     "from aiidalab_widgets_base import ProcessFollowerWidget, ProgressBarWidget, ProcessReportWidget\n",
-    "from aiidalab_widgets_base import ProcessInputsWidget, ProcessOutputsWidget, ProcessCallStackWidget, RunningCalcJobOutputWidget\n",
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile()"
+    "from aiidalab_widgets_base import ProcessInputsWidget, ProcessOutputsWidget, ProcessCallStackWidget, RunningCalcJobOutputWidget"
    ]
   },
   {
@@ -116,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/process.ipynb
+++ b/notebooks/process.ipynb
@@ -102,7 +102,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -116,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/process_list.ipynb
+++ b/notebooks/process_list.ipynb
@@ -29,7 +29,10 @@
     "import ipywidgets as ipw\n",
     "from aiidalab_widgets_base import ProcessListWidget\n",
     "from traitlets import dlink\n",
-    "from plumpy import ProcessState"
+    "from plumpy import ProcessState\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
    ]
   },
   {

--- a/notebooks/process_list.ipynb
+++ b/notebooks/process_list.ipynb
@@ -26,13 +26,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ipywidgets as ipw\n",
     "from aiidalab_widgets_base import ProcessListWidget\n",
     "from traitlets import dlink\n",
-    "from plumpy import ProcessState\n",
-    "from aiida import load_profile\n",
-    "\n",
-    "load_profile()"
+    "from plumpy import ProcessState"
    ]
   },
   {
@@ -128,7 +136,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -26,7 +26,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import aiidalab_widgets_base as awb"
+    "import aiidalab_widgets_base as awb\n",
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile()"
    ]
   },
   {

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -26,10 +26,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import aiidalab_widgets_base as awb\n",
     "from aiida import load_profile\n",
     "\n",
-    "load_profile()"
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiidalab_widgets_base as awb"
    ]
   },
   {

--- a/notebooks/wizard_apps.ipynb
+++ b/notebooks/wizard_apps.ipynb
@@ -13,6 +13,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b5256919",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from aiida import load_profile\n",
+    "\n",
+    "load_profile();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "thirty-catholic",
    "metadata": {},
    "outputs": [],
@@ -329,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_bug_report.py
+++ b/tests/test_bug_report.py
@@ -2,20 +2,17 @@ import base64
 import json
 import zlib
 
-from aiidalab_widgets_base.bug_report import (
-    get_environment_fingerprint,
-    parse_environment_fingerprint,
-)
+from aiidalab_widgets_base import bug_report
 
 
 def test_fingerprint_parser():
     """Test get_environment_fingerprint function and parse it out."""
 
     encoding = "utf-8"
-    fingerprint = get_environment_fingerprint(encoding)
+    fingerprint = bug_report.get_environment_fingerprint(encoding)
 
     # Parse the fingerprint.
-    data = parse_environment_fingerprint(fingerprint)
+    data = bug_report.parse_environment_fingerprint(fingerprint)
 
     # To test, manually generate the fingerprint and compare it to the output of the parser.
     json_data = json.dumps(data, separators=(",", ":"))

--- a/tests/test_bug_report.py
+++ b/tests/test_bug_report.py
@@ -2,13 +2,14 @@ import base64
 import json
 import zlib
 
+from aiidalab_widgets_base.bug_report import (
+    get_environment_fingerprint,
+    parse_environment_fingerprint,
+)
+
 
 def test_fingerprint_parser():
     """Test get_environment_fingerprint function and parse it out."""
-    from aiidalab_widgets_base.bug_report import (
-        get_environment_fingerprint,
-        parse_environment_fingerprint,
-    )
 
     encoding = "utf-8"
     fingerprint = get_environment_fingerprint(encoding)

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -1,18 +1,15 @@
 import pytest
 from aiida import orm
 
-import aiidalab_widgets_base as awb
-from aiidalab_widgets_base.computational_resources import (
-    AiidaCodeSetup,
-    AiidaComputerSetup,
-    SshComputerSetup,
-)
+from aiidalab_widgets_base import computational_resources
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_computaional_resources_widget(aiida_local_code_bash):
     """Test the ComputationalResourcesWidget."""
-    widget = awb.ComputationalResourcesWidget(default_calc_job_plugin="bash")
+    widget = computational_resources.ComputationalResourcesWidget(
+        default_calc_job_plugin="bash"
+    )
 
     # Get the list of currently installed codes.
     codes_dict = widget._get_codes()
@@ -22,7 +19,7 @@ def test_computaional_resources_widget(aiida_local_code_bash):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_ssh_computer_setup_widget():
     """Test the SshComputerSetup."""
-    widget = SshComputerSetup()
+    widget = computational_resources.SshComputerSetup()
 
     ssh_config = {
         "hostname": "daint.cscs.ch",
@@ -67,7 +64,7 @@ def test_ssh_computer_setup_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_aiida_computer_setup_widget():
     """Test the AiidaComputerSetup."""
-    widget = AiidaComputerSetup()
+    widget = computational_resources.AiidaComputerSetup()
 
     # At the beginning, the computer_name should be an empty string.
     assert widget.label.value == ""
@@ -118,7 +115,7 @@ def test_aiida_computer_setup_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_aiida_code_setup(aiida_localhost):
     """Test the AiidaCodeSetup."""
-    widget = AiidaCodeSetup()
+    widget = computational_resources.AiidaCodeSetup()
 
     # At the beginning, the code_name should be an empty string.
     assert widget.label.value == ""
@@ -160,7 +157,7 @@ def test_aiida_code_setup(aiida_localhost):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_computer_dropdown_widget(aiida_localhost):
     """Test the ComputerDropdownWidget."""
-    widget = awb.ComputerDropdownWidget()
+    widget = computational_resources.ComputerDropdownWidget()
 
     assert "localhost" in widget.computers
 

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -1,11 +1,17 @@
 import pytest
+from aiida import orm
+
+import aiidalab_widgets_base as awb
+from aiidalab_widgets_base.computational_resources import (
+    AiidaCodeSetup,
+    AiidaComputerSetup,
+    SshComputerSetup,
+)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_computaional_resources_widget(aiida_local_code_bash):
     """Test the ComputationalResourcesWidget."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.ComputationalResourcesWidget(default_calc_job_plugin="bash")
 
     # Get the list of currently installed codes.
@@ -16,8 +22,6 @@ def test_computaional_resources_widget(aiida_local_code_bash):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_ssh_computer_setup_widget():
     """Test the SshComputerSetup."""
-    from aiidalab_widgets_base.computational_resources import SshComputerSetup
-
     widget = SshComputerSetup()
 
     ssh_config = {
@@ -63,10 +67,6 @@ def test_ssh_computer_setup_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_aiida_computer_setup_widget():
     """Test the AiidaComputerSetup."""
-    from aiida import orm
-
-    from aiidalab_widgets_base.computational_resources import AiidaComputerSetup
-
     widget = AiidaComputerSetup()
 
     # At the beginning, the computer_name should be an empty string.
@@ -118,10 +118,6 @@ def test_aiida_computer_setup_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_aiida_code_setup(aiida_localhost):
     """Test the AiidaCodeSetup."""
-    from aiida import orm
-
-    from aiidalab_widgets_base.computational_resources import AiidaCodeSetup
-
     widget = AiidaCodeSetup()
 
     # At the beginning, the code_name should be an empty string.
@@ -164,8 +160,6 @@ def test_aiida_code_setup(aiida_localhost):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_computer_dropdown_widget(aiida_localhost):
     """Test the ComputerDropdownWidget."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.ComputerDropdownWidget()
 
     assert "localhost" in widget.computers

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,10 +1,10 @@
 import ase
 
+from aiidalab_widgets_base import CodQueryWidget, OptimadeQueryWidget
+
 
 def test_cod_query_widget():
     """Test the COD query widget."""
-    from aiidalab_widgets_base import CodQueryWidget
-
     widget = CodQueryWidget()
 
     # Enter the query string.
@@ -23,8 +23,6 @@ def test_cod_query_widget():
 
 def test_optimade_query_widget():
     """Test the OPTIMADE query widget."""
-    from aiidalab_widgets_base import OptimadeQueryWidget
-
     widget = OptimadeQueryWidget()
 
     # At the present state I cannot check much. Most of the variables are locals of the  __init__ method.

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,10 +1,9 @@
 import ase
 
-from aiidalab_widgets_base import CodQueryWidget, OptimadeQueryWidget
-
-
 def test_cod_query_widget():
     """Test the COD query widget."""
+    from aiidalab_widgets_base import CodQueryWidget
+    
     widget = CodQueryWidget()
 
     # Enter the query string.
@@ -23,6 +22,8 @@ def test_cod_query_widget():
 
 def test_optimade_query_widget():
     """Test the OPTIMADE query widget."""
+    from aiidalab_widgets_base import OptimadeQueryWidget
+    
     widget = OptimadeQueryWidget()
 
     # At the present state I cannot check much. Most of the variables are locals of the  __init__ method.

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,9 +1,10 @@
 import ase
 
+
 def test_cod_query_widget():
     """Test the COD query widget."""
     from aiidalab_widgets_base import CodQueryWidget
-    
+
     widget = CodQueryWidget()
 
     # Enter the query string.
@@ -23,7 +24,7 @@ def test_cod_query_widget():
 def test_optimade_query_widget():
     """Test the OPTIMADE query widget."""
     from aiidalab_widgets_base import OptimadeQueryWidget
-    
+
     widget = OptimadeQueryWidget()
 
     # At the present state I cannot check much. Most of the variables are locals of the  __init__ method.

--- a/tests/test_elns.py
+++ b/tests/test_elns.py
@@ -1,12 +1,11 @@
+from aiidalab_widgets_base import elns
+from aiidalab_eln import CheminfoElnConnector
+
 def test_connect_to_eln(mock_eln_config):
     """Test the connect_to_eln function."""
-    from aiidalab_eln import CheminfoElnConnector
+    mock_eln_config.mock(original_config=elns.ELN_CONFIG)
 
-    from aiidalab_widgets_base.elns import ELN_CONFIG, connect_to_eln
-
-    mock_eln_config.mock(original_config=ELN_CONFIG)
-
-    eln, message = connect_to_eln(eln_instance="any_random_eln")
+    eln, message = elns.connect_to_eln(eln_instance="any_random_eln")
     assert eln is None
     assert message.startswith("Can't open")
 
@@ -14,12 +13,12 @@ def test_connect_to_eln(mock_eln_config):
     mock_eln_config.write(config_dictionary={})
 
     # Now check that empty config file is identified, but has no content.
-    eln, message = connect_to_eln()
+    eln, message = elns.connect_to_eln()
     assert eln is None
     assert message.startswith(
         "No ELN instance was provided, the default ELN instance is not configured either."
     )
-    eln, message = connect_to_eln(eln_instance="any_random_eln")
+    eln, message = elns.connect_to_eln(eln_instance="any_random_eln")
     assert eln is None
     assert message == "Didn't find configuration for the 'any_random_eln' instance."
 
@@ -27,7 +26,7 @@ def test_connect_to_eln(mock_eln_config):
     mock_eln_config.populate_mock_config_with_cheminfo()
 
     # Now check that the config file is identified and has content.
-    eln, message = connect_to_eln()
+    eln, message = elns.connect_to_eln()
     assert isinstance(eln, CheminfoElnConnector)
 
     mock_eln_config.restore()
@@ -39,9 +38,7 @@ def test_eln_import_widget():
     # At the moment, we do a very minimal test of the widget, because it requires a running ELN instance.
     # TODO: add a mock ELN instance.
 
-    from aiidalab_widgets_base.elns import ElnImportWidget
-
-    widget = ElnImportWidget()
+    widget = elns.ElnImportWidget()
     assert widget.node is None
 
 
@@ -51,13 +48,11 @@ def test_eln_export_widget(structure_data_object, mock_eln_config):
     # At the moment, we do a very minimal test of the widget, because it requires a running ELN instance.
     # TODO: add a mock ELN instance.
 
-    from aiidalab_widgets_base.elns import ELN_CONFIG, ElnExportWidget
-
-    mock_eln_config.mock(original_config=ELN_CONFIG)
+    mock_eln_config.mock(original_config=elns.ELN_CONFIG)
 
     mock_eln_config.populate_mock_config_with_cheminfo()
 
-    widget = ElnExportWidget()
+    widget = elns.ElnExportWidget()
     assert widget.node is None
 
     widget.node = structure_data_object
@@ -68,11 +63,9 @@ def test_eln_export_widget(structure_data_object, mock_eln_config):
 
 
 def test_eln_configure_widget(mock_eln_config):
-    from aiidalab_widgets_base.elns import ELN_CONFIG, ElnConfigureWidget
+    mock_eln_config.mock(original_config=elns.ELN_CONFIG)
 
-    mock_eln_config.mock(original_config=ELN_CONFIG)
-
-    widget = ElnConfigureWidget()
+    widget = elns.ElnConfigureWidget()
     assert widget.eln_instance.options == (("Setup new ELN", {}),)
 
     widget.eln_types.value = "cheminfo"

--- a/tests/test_elns.py
+++ b/tests/test_elns.py
@@ -1,5 +1,7 @@
-from aiidalab_widgets_base import elns
 from aiidalab_eln import CheminfoElnConnector
+
+from aiidalab_widgets_base import elns
+
 
 def test_connect_to_eln(mock_eln_config):
     """Test the connect_to_eln function."""

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,7 @@
 import pytest
+
 from aiidalab_widgets_base import export
+
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_export_button_widget(multiply_add_completed_workchain, monkeypatch, tmp_path):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,13 +1,12 @@
 import pytest
-
+from aiidalab_widgets_base import export
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_export_button_widget(multiply_add_completed_workchain, monkeypatch, tmp_path):
     """Test the export button widget."""
-    from aiidalab_widgets_base.export import ExportButtonWidget
 
     process = multiply_add_completed_workchain
-    button = ExportButtonWidget(process)
+    button = export.ExportButtonWidget(process)
     assert button.description == f"Export workflow ({process.id})"
 
     # Test the export button. monkeypatch the `mkdtemp` function to return a

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,5 +1,7 @@
 import pytest
+
 from aiidalab_widgets_base import nodes
+
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_nodes_tree_widget(multiply_add_completed_workchain):

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,14 +1,12 @@
 import pytest
-
+from aiidalab_widgets_base import nodes
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_nodes_tree_widget(multiply_add_completed_workchain):
     """Test ProcessNodesTreeWidget with a simple `WorkChainNode`"""
 
-    from aiidalab_widgets_base.nodes import NodesTreeWidget
-
     process = multiply_add_completed_workchain
-    tree = NodesTreeWidget()
+    tree = nodes.NodesTreeWidget()
     tree.nodes = [process]
 
     # main node is selected
@@ -28,10 +26,9 @@ def test_nodes_tree_widget(multiply_add_completed_workchain):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_open_aiida_node_in_app_widget(multiply_add_completed_workchain):
     """ "Test OpenAiidaNodeInAppWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.nodes import OpenAiidaNodeInAppWidget
 
     process = multiply_add_completed_workchain
-    open_node_in_app = OpenAiidaNodeInAppWidget()
+    open_node_in_app = nodes.OpenAiidaNodeInAppWidget()
 
     assert len(open_node_in_app.tab.children) == 0
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -3,7 +3,7 @@ from aiida import engine, orm
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
 import aiidalab_widgets_base as awb
-from aiidalab_widgets_base import process
+
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_submit_button_widget(multiply_add_process_builder_ready):
@@ -32,6 +32,8 @@ def test_submit_button_widget(multiply_add_process_builder_ready):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_inputs_widget(generate_calc_job_node):
     """Test ProcessInputWidget with a simple `CalcJobNode`"""
+    from aiidalab_widgets_base.process import ProcessInputsWidget
+
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -42,9 +44,9 @@ def test_process_inputs_widget(generate_calc_job_node):
     )
 
     # Test the widget can be instantiated with empty inputs
-    process_input_widget = process.ProcessInputsWidget()
+    process_input_widget = ProcessInputsWidget()
 
-    process_input_widget = process.ProcessInputsWidget(process=process)
+    process_input_widget = ProcessInputsWidget(process=process)
     input_dropdown = process_input_widget._inputs
 
     assert "parameters" in [key for key, _ in input_dropdown.options]
@@ -62,11 +64,13 @@ def test_process_inputs_widget(generate_calc_job_node):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_outputs_widget(multiply_add_completed_workchain):
     """Test ProcessOutputWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import ProcessOutputsWidget
+
     # Test the widget can be instantiated with empty inputs
-    widget = process.ProcessOutputsWidget()
+    widget = ProcessOutputsWidget()
 
     # Test the widget can be instantiated with a process
-    widget = process.ProcessOutputsWidget(process=multiply_add_completed_workchain)
+    widget = ProcessOutputsWidget(process=multiply_add_completed_workchain)
 
     # Simulate output selection.
     widget.show_selected_output(change={"new": "result"})
@@ -75,15 +79,17 @@ def test_process_outputs_widget(multiply_add_completed_workchain):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_follower_widget(multiply_add_process_builder_ready, daemon_client):
     """Test ProcessFollowerWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import ProcessFollowerWidget
+
     # Test the widget can be instantiated with empty inputs
-    widget = process.ProcessFollowerWidget()
+    widget = ProcessFollowerWidget()
 
     if daemon_client.is_daemon_running:
         daemon_client.stop_daemon(wait=True)
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = process.ProcessFollowerWidget(process=process)
+    widget = ProcessFollowerWidget(process=process)
 
     daemon_client.start_daemon()
 
@@ -98,8 +104,10 @@ def test_process_report_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessReportWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import ProcessReportWidget
+
     # Test the widget can be instantiated with empty inputs
-    process.ProcessReportWidget()
+    ProcessReportWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -107,7 +115,7 @@ def test_process_report_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = process.ProcessReportWidget(process=process)
+    widget = ProcessReportWidget(process=process)
     assert (
         widget.value == "No log messages recorded for this entry"
     )  # No report produced yet.
@@ -125,8 +133,10 @@ def test_process_call_stack_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessCallStackWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import ProcessCallStackWidget
+
     # Test the widget can be instantiated with empty inputs
-    process.ProcessCallStackWidget()
+    ProcessCallStackWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -134,7 +144,7 @@ def test_process_call_stack_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = process.ProcessCallStackWidget(process=process)
+    widget = ProcessCallStackWidget(process=process)
     assert widget.value.endswith("Created")
 
     # Starting the daemon and waiting for the process to complete.
@@ -151,8 +161,10 @@ def test_progress_bar_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProgressBarWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base import ProgressBarWidget
+
     # Test the widget can be instantiated with empty inputs
-    process.ProgressBarWidget()
+    ProgressBarWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -160,7 +172,7 @@ def test_progress_bar_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = process.ProgressBarWidget(process=process)
+    widget = ProgressBarWidget(process=process)
     assert widget.state.value == "Created"
 
     # Starting the daemon and waiting for the process to complete.
@@ -175,6 +187,8 @@ def test_progress_bar_widget(
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_calcjob_output_widget(generate_calc_job_node):
     """Test CalcJobOutputWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import CalcJobOutputWidget
+
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -184,15 +198,17 @@ def test_calcjob_output_widget(generate_calc_job_node):
         }
     )
     # Test the widget can be instantiated with empty inputs
-    process.CalcJobOutputWidget()
+    CalcJobOutputWidget()
 
     # Test the widget can be instantiated with a process
-    process.CalcJobOutputWidget(calculation=process)
+    CalcJobOutputWidget(calculation=process)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_running_calcjob_output_widget(generate_calc_job_node):
     """Test RunningCalcJobOutputWidget with a simple `WorkChainNode`"""
+    from aiidalab_widgets_base.process import RunningCalcJobOutputWidget
+
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -203,13 +219,15 @@ def test_running_calcjob_output_widget(generate_calc_job_node):
     )
 
     # Test the widget can be instantiated with a process
-    process.RunningCalcJobOutputWidget(calculation=process)
+    RunningCalcJobOutputWidget(calculation=process)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_list_widget(multiply_add_completed_workchain):
     """Test ProcessListWidget with a simple `WorkChainNode`"""
-    process.ProcessListWidget()
+    from aiidalab_widgets_base.process import ProcessListWidget
+
+    ProcessListWidget()
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
@@ -217,7 +235,9 @@ def test_process_monitor(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessMonitor with a simple `WorkChainNode`"""
-    process.ProcessMonitor()
+    from aiidalab_widgets_base.process import ProcessMonitor
+
+    ProcessMonitor()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -230,7 +250,7 @@ def test_process_monitor(
         nonlocal test_variable
         test_variable = True
 
-    widget = process.ProcessMonitor(value=process.uuid, callbacks=[f])
+    widget = ProcessMonitor(value=process.uuid, callbacks=[f])
 
     # Starting the daemon and waiting for the process to complete.
     daemon_client.start_daemon()
@@ -245,4 +265,7 @@ def test_process_monitor(
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_nodes_tree_widget(multiply_add_completed_workchain):
     """Test ProcessNodesTreeWidget with a simple `WorkChainNode`"""
-    process.ProcessNodesTreeWidget(value=multiply_add_completed_workchain.uuid)
+
+    from aiidalab_widgets_base.process import ProcessNodesTreeWidget
+
+    ProcessNodesTreeWidget(value=multiply_add_completed_workchain.uuid)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,13 +1,13 @@
 import pytest
 from aiida import engine, orm
+from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
 
+import aiidalab_widgets_base as awb
+from aiidalab_widgets_base import process
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_submit_button_widget(multiply_add_process_builder_ready):
     """Test SubmitButtonWidget with a simple `WorkChainNode`"""
-    from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
-
-    import aiidalab_widgets_base as awb
 
     def hook(_=None):
         pass
@@ -32,8 +32,6 @@ def test_submit_button_widget(multiply_add_process_builder_ready):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_inputs_widget(generate_calc_job_node):
     """Test ProcessInputWidget with a simple `CalcJobNode`"""
-    from aiidalab_widgets_base.process import ProcessInputsWidget
-
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -44,9 +42,9 @@ def test_process_inputs_widget(generate_calc_job_node):
     )
 
     # Test the widget can be instantiated with empty inputs
-    process_input_widget = ProcessInputsWidget()
+    process_input_widget = process.ProcessInputsWidget()
 
-    process_input_widget = ProcessInputsWidget(process=process)
+    process_input_widget = process.ProcessInputsWidget(process=process)
     input_dropdown = process_input_widget._inputs
 
     assert "parameters" in [key for key, _ in input_dropdown.options]
@@ -64,13 +62,11 @@ def test_process_inputs_widget(generate_calc_job_node):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_outputs_widget(multiply_add_completed_workchain):
     """Test ProcessOutputWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessOutputsWidget
-
     # Test the widget can be instantiated with empty inputs
-    widget = ProcessOutputsWidget()
+    widget = process.ProcessOutputsWidget()
 
     # Test the widget can be instantiated with a process
-    widget = ProcessOutputsWidget(process=multiply_add_completed_workchain)
+    widget = process.ProcessOutputsWidget(process=multiply_add_completed_workchain)
 
     # Simulate output selection.
     widget.show_selected_output(change={"new": "result"})
@@ -79,17 +75,15 @@ def test_process_outputs_widget(multiply_add_completed_workchain):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_follower_widget(multiply_add_process_builder_ready, daemon_client):
     """Test ProcessFollowerWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessFollowerWidget
-
     # Test the widget can be instantiated with empty inputs
-    widget = ProcessFollowerWidget()
+    widget = process.ProcessFollowerWidget()
 
     if daemon_client.is_daemon_running:
         daemon_client.stop_daemon(wait=True)
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = ProcessFollowerWidget(process=process)
+    widget = process.ProcessFollowerWidget(process=process)
 
     daemon_client.start_daemon()
 
@@ -104,10 +98,8 @@ def test_process_report_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessReportWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessReportWidget
-
     # Test the widget can be instantiated with empty inputs
-    ProcessReportWidget()
+    process.ProcessReportWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -115,7 +107,7 @@ def test_process_report_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = ProcessReportWidget(process=process)
+    widget = process.ProcessReportWidget(process=process)
     assert (
         widget.value == "No log messages recorded for this entry"
     )  # No report produced yet.
@@ -133,10 +125,8 @@ def test_process_call_stack_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessCallStackWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessCallStackWidget
-
     # Test the widget can be instantiated with empty inputs
-    ProcessCallStackWidget()
+    process.ProcessCallStackWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -144,7 +134,7 @@ def test_process_call_stack_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = ProcessCallStackWidget(process=process)
+    widget = process.ProcessCallStackWidget(process=process)
     assert widget.value.endswith("Created")
 
     # Starting the daemon and waiting for the process to complete.
@@ -161,10 +151,8 @@ def test_progress_bar_widget(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProgressBarWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base import ProgressBarWidget
-
     # Test the widget can be instantiated with empty inputs
-    ProgressBarWidget()
+    process.ProgressBarWidget()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -172,7 +160,7 @@ def test_progress_bar_widget(
     process = engine.submit(multiply_add_process_builder_ready)
 
     # Test the widget can be instantiated with a process
-    widget = ProgressBarWidget(process=process)
+    widget = process.ProgressBarWidget(process=process)
     assert widget.state.value == "Created"
 
     # Starting the daemon and waiting for the process to complete.
@@ -187,8 +175,6 @@ def test_progress_bar_widget(
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_calcjob_output_widget(generate_calc_job_node):
     """Test CalcJobOutputWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import CalcJobOutputWidget
-
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -198,17 +184,15 @@ def test_calcjob_output_widget(generate_calc_job_node):
         }
     )
     # Test the widget can be instantiated with empty inputs
-    CalcJobOutputWidget()
+    process.CalcJobOutputWidget()
 
     # Test the widget can be instantiated with a process
-    CalcJobOutputWidget(calculation=process)
+    process.CalcJobOutputWidget(calculation=process)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_running_calcjob_output_widget(generate_calc_job_node):
     """Test RunningCalcJobOutputWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import RunningCalcJobOutputWidget
-
     process = generate_calc_job_node(
         inputs={
             "parameters": orm.Int(1),
@@ -219,15 +203,13 @@ def test_running_calcjob_output_widget(generate_calc_job_node):
     )
 
     # Test the widget can be instantiated with a process
-    RunningCalcJobOutputWidget(calculation=process)
+    process.RunningCalcJobOutputWidget(calculation=process)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_list_widget(multiply_add_completed_workchain):
     """Test ProcessListWidget with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessListWidget
-
-    ProcessListWidget()
+    process.ProcessListWidget()
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
@@ -235,9 +217,7 @@ def test_process_monitor(
     multiply_add_process_builder_ready, daemon_client, await_for_process_completeness
 ):
     """Test ProcessMonitor with a simple `WorkChainNode`"""
-    from aiidalab_widgets_base.process import ProcessMonitor
-
-    ProcessMonitor()
+    process.ProcessMonitor()
 
     # Stopping the daemon and submitting the process.
     if daemon_client.is_daemon_running:
@@ -250,7 +230,7 @@ def test_process_monitor(
         nonlocal test_variable
         test_variable = True
 
-    widget = ProcessMonitor(value=process.uuid, callbacks=[f])
+    widget = process.ProcessMonitor(value=process.uuid, callbacks=[f])
 
     # Starting the daemon and waiting for the process to complete.
     daemon_client.start_daemon()
@@ -265,7 +245,4 @@ def test_process_monitor(
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_process_nodes_tree_widget(multiply_add_completed_workchain):
     """Test ProcessNodesTreeWidget with a simple `WorkChainNode`"""
-
-    from aiidalab_widgets_base.process import ProcessNodesTreeWidget
-
-    ProcessNodesTreeWidget(value=multiply_add_completed_workchain.uuid)
+    process.ProcessNodesTreeWidget(value=multiply_add_completed_workchain.uuid)

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -4,12 +4,11 @@ import ase
 import numpy as np
 import pytest
 
+import aiidalab_widgets_base as awb
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_manager_widget(structure_data_object):
     """Test the `StructureManagerWidget`."""
-    import aiidalab_widgets_base as awb
-
     structure_manager_widget = awb.StructureManagerWidget(
         importers=[
             awb.StructureUploadWidget(title="From computer"),
@@ -57,8 +56,6 @@ def test_structure_manager_widget(structure_data_object):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_browser_widget(structure_data_object):
     """Test the `StructureBrowserWidget`."""
-    import aiidalab_widgets_base as awb
-
     structure_browser_widget = awb.StructureBrowserWidget()
     assert structure_browser_widget.structure is None
 
@@ -81,8 +78,6 @@ def test_structure_browser_widget(structure_data_object):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_upload_widget():
     """Test the `StructureUploadWidget`."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.StructureUploadWidget()
     assert widget.structure is None
 
@@ -108,8 +103,6 @@ def test_structure_upload_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_examples_widget():
     """Test the `StructureExamplesWidget`."""
-    import aiidalab_widgets_base as awb
-
     this_folder = Path(__file__).parent
 
     widget = awb.StructureExamplesWidget(
@@ -131,8 +124,6 @@ def test_structure_examples_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_smiles_widget():
     """Test the `SmilesWidget`."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.SmilesWidget()
     assert widget.structure is None
 
@@ -146,8 +137,6 @@ def test_smiles_widget():
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_basic_cell_editor_widget(structure_data_object):
     """Test the `BasicCellEditor`."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.BasicCellEditor()
     assert widget.structure is None
 
@@ -167,8 +156,6 @@ def test_basic_cell_editor_widget(structure_data_object):
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_basic_structure_editor(structure_data_object):
     """Test the `BasicStructureEditor`."""
-    import aiidalab_widgets_base as awb
-
     widget = awb.BasicStructureEditor()
     assert widget.structure is None
 

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -6,6 +6,7 @@ import pytest
 
 import aiidalab_widgets_base as awb
 
+
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_manager_widget(structure_data_object):
     """Test the `StructureManagerWidget`."""

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -34,7 +34,7 @@ def test_several_data_viewers(
             },
         }
     )
-    v = viewer(process)
+    v = viewers.viewer(process)
     assert isinstance(v, viewers.ProcessNodeViewerWidget)
 
 

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -1,28 +1,28 @@
 import pytest
 from aiida import orm
 
+from aiidalab_widgets_base import viewers
+
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_several_data_viewers(
     bands_data_object, folder_data_object, generate_calc_job_node
 ):
-    from aiidalab_widgets_base import viewer, viewers
-
-    v = viewer(orm.Int(1))
+    v = viewers.viewer(orm.Int(1))
 
     # No viewer for Int, so it should return the input
     assert isinstance(v, orm.Int)
 
     # DictViewer
-    v = viewer(orm.Dict(dict={"a": 1}))
+    v = viewers.viewer(orm.Dict(dict={"a": 1}))
     assert isinstance(v, viewers.DictViewer)
 
     # BandsDataViewer
-    v = viewer(bands_data_object)
+    v = viewers.viewer(bands_data_object)
     assert isinstance(v, viewers.BandsDataViewer)
 
     # FolderDataViewer
-    v = viewer(folder_data_object)
+    v = viewers.viewer(folder_data_object)
     assert isinstance(v, viewers.FolderDataViewer)
 
     # ProcessNodeViewer
@@ -40,9 +40,7 @@ def test_several_data_viewers(
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_data_viwer(structure_data_object):
-    from aiidalab_widgets_base import viewer, viewers
-
-    v = viewer(structure_data_object)
+    v = viewers.viewer(structure_data_object)
     assert isinstance(v, viewers.StructureDataViewer)
 
     # Selection of atoms.

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -3,8 +3,8 @@ import traitlets as tl
 
 from aiidalab_widgets_base import WizardAppWidget, WizardAppWidgetStep
 
-def test_wizard_app_widget():
 
+def test_wizard_app_widget():
     class Step1(ipw.HBox, WizardAppWidgetStep):
         config = tl.Bool()
 

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -1,9 +1,9 @@
 import ipywidgets as ipw
 import traitlets as tl
 
+from aiidalab_widgets_base import WizardAppWidget, WizardAppWidgetStep
 
 def test_wizard_app_widget():
-    from aiidalab_widgets_base import WizardAppWidget, WizardAppWidgetStep
 
     class Step1(ipw.HBox, WizardAppWidgetStep):
         config = tl.Bool()

--- a/tests_notebooks/test_notebooks.py
+++ b/tests_notebooks/test_notebooks.py
@@ -21,6 +21,7 @@ def test_aiida_datatypes_viewers(selenium_driver, final_screenshot):
     driver.set_window_size(1000, 2000)
     driver.find_element(By.CLASS_NAME, "widget-label")
     driver.find_element(By.XPATH, '//button[text()="Clear selection"]')
+    driver.find_element(By.XPATH, '//p[text()="Warning:"]')
     time.sleep(5)
 
 


### PR DESCRIPTION
The `load_profile()` in `__init__.py` to load the profile in module scope was introduced by PR https://github.com/aiidalab/aiidalab-widgets-base/pull/12. It is not needed anymore since the computer and code widgets are updated and can update the dropdown dynamically. 

More problematically that this makes the profile loaded in the unit tests and overrides the test profile which makes it has to put the module load inside every test. There is also the problem that if the user want to test the widgets in a newly create python environment that doesn't have an AiiDA profile setup impossible. 

- [x] move modules import from test to file in front.

Before meeting this, we should make sure that apps which depend on AWB, load profiles in the notebooks. We checkbox the apps if they do:

- [x] [Aurora app](https://github.com/epfl-theos/aiidalab-aurora) (doesn't depend on AWB)
- [ ] [Molecules app](https://github.com/nanotech-empa/aiidalab-empa-molecules)
- [x] [LSMO app](https://github.com/lsmo-epfl/aiidalab-epfl-lsmo.git) (not migrated)
- [ ] [Martket place - use case 3](https://github.com/daniel-sintef/aiidalab-uc3)
- [x] [Graphene nanoribbons](https://github.com/nanotech-empa/aiidalab-empa-nanoribbons)
- [ ] [Quantum ESPRESSO app](https://github.com/aiidalab/aiidalab-qe)
- [x] [Scanning Probe Microscopy](https://github.com/nanotech-empa/aiidalab-empa-scanning-probe) (deprecated)
- [ ] [SSSP toolbox](https://github.com/aiidalab/aiidalab-sssp)
- [x] [On-Surface Chemistry](https://github.com/nanotech-empa/aiidalab-empa-surfaces)

