### PR TITLE
Remove dynamic version attribute from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiidalab_widgets_base
-version = attr: aiidalab_widgets_base.__version__
+version = 2.0.0
 description = Reusable widgets for AiiDAlab applications.
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -84,3 +84,5 @@ push = True
 [bumpver:file_patterns]
 aiidalab_widgets_base/__init__.py =
     __version__ = "{pep440_version}"
+setup.cfg =
+    version = {pep440_version}


### PR DESCRIPTION
Dynamic version attributes are not yet supported in the `aiidalab` package. 
Since AWB is currently an App, and not just a library, we need to use a static version.

Here's what you currently get for AWB 2.0.0
```console
$ aiidalab list
App name               Version              Path
---------------------  -------------------  ---------------------------------------
aiidalab-widgets-base  AppVersion.UNKNOWN•  /home/jovyan/apps/aiidalab-widgets-base
home                   v23.03.1             /home/jovyan/apps/home
```