### PR TITLE
Lazy import optimade_client

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -154,22 +154,24 @@ class OptimadeQueryWidget(ipw.VBox):
     ) -> None:
         from optimade_client import default_parameters, query_filter, query_provider
 
-        _disable_providers = default_parameters.DISABLE_PROVIDERS
-        _skip_databases = default_parameters.SKIP_DATABASE
-        _skip_providers = default_parameters.SKIP_PROVIDERS
-        _provider_database_groupings = default_parameters.PROVIDER_DATABASE_GROUPINGS
-
         providers_header = ipw.HTML("<h4>Select a provider</h4>")
         providers = query_provider.OptimadeQueryProviderWidget(
             embedded=embedded,
             width_ratio=kwargs.pop("width_ratio", None),
             width_space=kwargs.pop("width_space", None),
             database_limit=kwargs.pop("database_limit", None),
-            disable_providers=kwargs.pop("disable_providers", _disable_providers),
-            skip_databases=kwargs.pop("skip_databases", _skip_databases),
-            skip_providers=kwargs.pop("skip_providers", _skip_providers),
+            disable_providers=kwargs.pop(
+                "disable_providers", default_parameters.DISABLE_PROVIDERS
+            ),
+            skip_databases=kwargs.pop(
+                "skip_databases", default_parameters.SKIP_DATABASE
+            ),
+            skip_providers=kwargs.pop(
+                "skip_providers", default_parameters.SKIP_DATABASE
+            ),
             provider_database_groupings=kwargs.pop(
-                "provider_database_groupings", _provider_database_groupings
+                "provider_database_groupings",
+                default_parameters.PROVIDER_DATABASE_GROUPINGS,
             ),
         )
         filters = query_filter.OptimadeQueryFilterWidget(

--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -3,8 +3,6 @@ import ase
 import ipywidgets as ipw
 import requests
 import traitlets as tl
-from aiida.tools.dbimporters.plugins.cod import CodDbImporter
-from optimade_client import default_parameters, query_filter, query_provider
 
 
 class CodQueryWidget(ipw.VBox):
@@ -69,6 +67,8 @@ class CodQueryWidget(ipw.VBox):
     @staticmethod
     def _query(idn=None, formula=None):
         """Make the actual query."""
+        from aiida.tools.dbimporters.plugins.cod import CodDbImporter
+
         importer = CodDbImporter()
         if idn is not None:
             return importer.query(id=idn)
@@ -146,28 +146,30 @@ class OptimadeQueryWidget(ipw.VBox):
 
     structure = tl.Instance(ase.Atoms, allow_none=True)
 
-    _disable_providers = default_parameters.DISABLE_PROVIDERS
-    _skip_databases = default_parameters.SKIP_DATABASE
-    _skip_providers = default_parameters.SKIP_PROVIDERS
-    _provider_database_groupings = default_parameters.PROVIDER_DATABASE_GROUPINGS
-
     def __init__(
         self,
         embedded: bool = True,
         title: str = None,
         **kwargs,
     ) -> None:
+        from optimade_client import default_parameters, query_filter, query_provider
+
+        _disable_providers = default_parameters.DISABLE_PROVIDERS
+        _skip_databases = default_parameters.SKIP_DATABASE
+        _skip_providers = default_parameters.SKIP_PROVIDERS
+        _provider_database_groupings = default_parameters.PROVIDER_DATABASE_GROUPINGS
+
         providers_header = ipw.HTML("<h4>Select a provider</h4>")
         providers = query_provider.OptimadeQueryProviderWidget(
             embedded=embedded,
             width_ratio=kwargs.pop("width_ratio", None),
             width_space=kwargs.pop("width_space", None),
             database_limit=kwargs.pop("database_limit", None),
-            disable_providers=kwargs.pop("disable_providers", self._disable_providers),
-            skip_databases=kwargs.pop("skip_databases", self._skip_databases),
-            skip_providers=kwargs.pop("skip_providers", self._skip_providers),
+            disable_providers=kwargs.pop("disable_providers", _disable_providers),
+            skip_databases=kwargs.pop("skip_databases", _skip_databases),
+            skip_providers=kwargs.pop("skip_providers", _skip_providers),
             provider_database_groupings=kwargs.pop(
-                "provider_database_groupings", self._provider_database_groupings
+                "provider_database_groupings", _provider_database_groupings
             ),
         )
         filters = query_filter.OptimadeQueryFilterWidget(


### PR DESCRIPTION
optimade_client brings a lot of dependencies that slow down module import, and in turn slow down app loading even for applications that do not use Optimade.

I haven't actually tested this code since I do not use the Optimade widget, please test as part of review.

NOTE: This is part of a larger effort to improve import times, documented here

https://aiida.discourse.group/t/why-is-aiidalab-base-widget-import-so-slow/32/18