### PR TITLE
Make notebook tests less flaky

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ docs =
     sphinxcontrib-details-directive
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=0.24
+    scikit-learn~=1.0
 
 [flake8]
 ignore =

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -4,8 +4,10 @@ from urllib.parse import urljoin
 
 import pytest
 import requests
+import selenium.webdriver.support.expected_conditions as ec
 from requests.exceptions import ConnectionError
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 def is_responsive(url):
@@ -89,6 +91,9 @@ def selenium_driver(selenium, notebook_service):
 
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
+        WebDriverWait(selenium, 100).until(
+            ec.invisibility_of_element((By.ID, "appmode-busy"))
+        )
 
         return selenium
 


### PR DESCRIPTION
We now wait until the Appmode loading gif disappears. We've been using this strategy in my app and in QeApp for a while and it seems to work well.