### PR TITLE
Bump scikit-learn

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ docs =
     sphinxcontrib-details-directive
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=0.24
+    scikit-learn~=1.0.0
 
 [flake8]
 ignore =


### PR DESCRIPTION
scikit-learn build for version 0.24 started failing due to new version of Cython so we bump the version to 1.0. Per docs, this version does not bring any breaking changes. https://scikit-learn.org/1.0/auto_examples/release_highlights/plot_release_highlights_1_0_0.html

We also only use the sklearn.PCA in SMILES widget, I've verified that it still works and checked the release notes that there are not API changes to this method.
https://scikit-learn.org/1.0/whats_new/v1.0.html#changes-1-0

In the near future I'd like to get rid of scikit-learn altogether since it is a very heavy dependency and we only use it for PCA to reorient the molecules generated from SMILES by RDkit. I have a suspicion that this step is not really needed, and if it is, we can simply vendor the PCA function.