### PR TITLE
Remove Transport dropdown in computer setup, assume SSH

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -733,9 +733,8 @@ class AiidaComputerSetup(ipw.VBox):
         )
 
         # Transport type.
-        self.transport = ipw.Dropdown(
-            value="core.local",
-            options=plugins.entry_point.get_entry_point_names("aiida.transports"),
+        self.transport = ipw.HTML(
+            value="SSH",
             description="Transport type:",
             style=STYLE,
         )
@@ -941,7 +940,6 @@ class AiidaComputerSetup(ipw.VBox):
         self.mpirun_command.value = "mpirun -n {tot_num_mpiprocs}"
         self.default_memory_per_machine_widget.value = ""
         self.mpiprocs_per_machine.value = 1
-        self.transport.value = "core.ssh"
         self.safe_interval.value = 30.0
         self.scheduler.value = "core.slurm"
         self.shebang.value = "#!/usr/bin/env bash"


### PR DESCRIPTION
It is not clear whether AiiDA Computer setup ever worked with any transport other than SSH,
but in any case the widget is clearly designed with SSH in mind so unless a clear need is found we can simply remove the 'Transport type" dropdown. Note the the value of this widget has not been used anywhere in the code, which is telling.

The localhost computer is setup in the AiiDAlab Docker image by default, and in the unlikely case that another one needs to be setup, such user probably knows how to set it up via verdi command line interface.

Fixes #417 