### PR TITLE
StructureViewer Download tab: pass file format explicitly

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -453,7 +453,7 @@ class _StructureDataBaseViewer(ipw.VBox):
         # 1. Choose download file format.
         self.file_format = ipw.Dropdown(
             label="Extended xyz",
-            # File extension and format may be differen. Therefore, we define both.
+            # File extension and format may be different. Therefore, we define both.
             options=(
                 ("xyz", {"extension": "xyz", "format": "xyz"}),
                 ("cif", {"extension": "cif", "format": "cif"}),
@@ -717,12 +717,12 @@ class _StructureDataBaseViewer(ipw.VBox):
 
     def download(self, change=None):  # pylint: disable=unused-argument
         """Prepare a structure for downloading."""
-        payload = self._prepare_payload()
+        payload = self._prepare_payload(self.file_format.value["format"])
         if payload is None:
             return
         suffix = f"pk-{self.pk}" if self.pk else "not-stored"
         self._download(
-            payload=self._prepare_payload(),
+            payload=payload,
             filename=f"""structure-{suffix}.{self.file_format.value["extension"]}""",
         )
 


### PR DESCRIPTION
The change in #501 broke my application because it changed the `file_format` traitlet, on which I was relying. 

I could update my app but it would be a bit complicated to support both old and new version, so I thought I'll make a small change here if that is okay with you @yakutovicha.

Incidentally, I also fixed a small bug where `_prepare_payload` function was called twice.