### PR TITLE
SmilesWidget: Canonicalize SMILES code

### DIFF
--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -150,6 +150,27 @@ def test_smiles_widget():
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
+def test_smiles_canonicalization():
+    """Test the SMILES canonicalization via RdKit."""
+    widget = awb.SmilesWidget()
+
+    # Should not change canonical smiles
+    assert widget.canonicalize_smiles("C") == "C"
+
+    # Should canonicalize this
+    canonical = widget.canonicalize_smiles("O=CC=C")
+    assert canonical == "C=CC=O"
+
+    # Should be idempotent
+    assert canonical == widget.canonicalize_smiles(canonical)
+
+    # Regression test for https://github.com/aiidalab/aiidalab-widgets-base/issues/505
+    # Throwing in this non-canonical string should not raise
+    nasty_smiles = "C=CC1=C(C2=CC=C(C3=CC=CC=C3)C=C2)C=C(C=C)C(C4=CC=C(C(C=C5)=CC=C5C(C=C6C=C)=C(C=C)C=C6C7=CC=C(C(C=C8)=CC=C8C(C=C9C=C)=C(C=C)C=C9C%10=CC=CC=C%10)C=C7)C=C4)=C1"
+    widget._rdkit_opt(nasty_smiles, steps=1)
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
 def test_basic_cell_editor_widget(structure_data_object):
     """Test the `BasicCellEditor`."""
     widget = awb.BasicCellEditor()


### PR DESCRIPTION
Canonicalize user-provided SMILES using RDKit. If the canonical name is different from the input SMILES, we print the canonical SMILES.

Test plan:
1. Input SMILES `C=CC1=C(C2=CC=C(C3=CC=CC=C3)C=C2)C=C(C=C)C(C4=CC=C(C(C=C5)=CC=C5C(C=C6C=C)=C(C=C)C=C6C7=CC=C(C(C=C8)=CC=C8C(C=C9C=C)=C(C=C)C=C9C%10=CC=CC=C%10)C=C7)C=C4)=C1`

should give you 
`C=Cc1cc(-c2ccc(-c3ccc(-c4cc(C=C)c(-c5ccc(-c6ccc(-c7cc(C=C)c(-c8ccc(-c9ccccc9)cc8)cc7C=C)cc6)cc5)cc4C=C)cc3)cc2)c(C=C)cc1-c1ccccc1`

and should not fail.

I also add a missing error check that caused uncaught exception in #505 

Closes #505. Closes #331