### PR TITLE
Get rid of deprecation warnings in computational_resources.py

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -223,7 +223,7 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
         self.inp_computer = ipw.Dropdown(
             options=[],
             description="Computer:",
-            disable=False,
+            disabled=False,
         )
         self.inp_computer.observe(self._computer_changed, names=["value", "options"])
 
@@ -231,7 +231,7 @@ class ComputationalResourcesDatabaseWidget(ipw.VBox):
         self.inp_code = ipw.Dropdown(
             options=[],
             description="Code:",
-            disable=False,
+            disabled=False,
         )
         self.inp_code.observe(self._code_changed, names=["value", "options"])
 

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -5,15 +5,15 @@ from aiidalab_widgets_base import computational_resources
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
-def test_computaional_resources_widget(aiida_local_code_bash):
+def test_computational_resources_widget(aiida_local_code_bash):
     """Test the ComputationalResourcesWidget."""
     widget = computational_resources.ComputationalResourcesWidget(
         default_calc_job_plugin="bash"
     )
 
     # Get the list of currently installed codes.
-    codes_dict = widget._get_codes()
-    assert "bash@localhost" in codes_dict
+    codes = widget._get_codes()
+    assert "bash@localhost" == codes[0][0]
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")


### PR DESCRIPTION
`pytest test/test_computational_resources.py` would generate 7 deprecation warnings coming from `ipywidgets` and `traitlets`.

Step towards fixing #490 