### PR TITLE
Fix/xx/increase timeout of di test

### DIFF
--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -68,7 +68,7 @@ def notebook_service(docker_ip, docker_services, aiidalab_exec):
     url = f"http://{docker_ip}:{port}"
     token = os.environ["JUPYTER_TOKEN"]
     docker_services.wait_until_responsive(
-        timeout=30.0, pause=0.1, check=lambda: is_responsive(url)
+        timeout=31.0, pause=0.1, check=lambda: is_responsive(url)
     )
     return url, token
 

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -91,7 +91,7 @@ def selenium_driver(selenium, notebook_service):
 
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
-        WebDriverWait(selenium, 120).until(
+        WebDriverWait(selenium, 240).until(
             ec.invisibility_of_element((By.ID, "appmode-busy"))
         )
 

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -68,7 +68,7 @@ def notebook_service(docker_ip, docker_services, aiidalab_exec):
     url = f"http://{docker_ip}:{port}"
     token = os.environ["JUPYTER_TOKEN"]
     docker_services.wait_until_responsive(
-        timeout=31.0, pause=0.1, check=lambda: is_responsive(url)
+        timeout=30.0, pause=0.1, check=lambda: is_responsive(url)
     )
     return url, token
 
@@ -84,14 +84,14 @@ def selenium_driver(selenium, notebook_service):
         # By default, let's allow selenium functions to retry for 10s
         # till a given element is loaded, see:
         # https://selenium-python.readthedocs.io/waits.html#implicit-waits
-        selenium.implicitly_wait(10)
+        selenium.implicitly_wait(30)
         window_width = 800
         window_height = 600
         selenium.set_window_size(window_width, window_height)
 
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
-        WebDriverWait(selenium, 100).until(
+        WebDriverWait(selenium, 120).until(
             ec.invisibility_of_element((By.ID, "appmode-busy"))
         )
 


### PR DESCRIPTION
The smoke test in https://github.com/aiidalab/aiidalab-widgets-base/pull/511 failed but because of structure notebooks. From the screenshots the notebook is still loading. I guess the `timeout=10` is too short?