### PR TITLE
Add timeout to cod query test to avoid test hang

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ dev =
     pytest-cov~=4.0
     pytest-docker~=1.0
     pytest-selenium~=4.0
+    pytest-timeout~=2.2
     selenium~=4.7.0
     webdriver-manager~=3.8
 smiles =

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,9 +1,12 @@
 import ase
+import pytest
 
 import aiidalab_widgets_base as awb
 from aiidalab_widgets_base.databases import ComputationalResourcesDatabaseWidget
 
 
+# timeout for the test
+@pytest.mark.timeout(30)
 def test_cod_query_widget():
     """Test the COD query widget."""
 


### PR DESCRIPTION
Temporary solution to timeout the cod query widget test.