### PR TITLE
Allow set key_filename/key_policy in computer configure

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -839,7 +839,19 @@ class AiidaComputerSetup(ipw.VBox):
             raise common.ValidationError(msg)
 
     def _configure_computer_ssh(self, computer: orm.Computer, user: orm.User):
-        """Configure the computer with SSH transport"""
+        """Configure the computer with SSH transport
+
+        There are three sources of authparams information:
+        - the SSH config file
+        - the computer_configure dictionary
+        - the default values
+
+        Priority is given to the computer_configure dictionary, then to the SSH config file, then to the default values.
+        At the moment, there is no overlap between the SSH config file and the computer_configure dictionary.
+
+        The proxyjump and proxycommend can be read from both the SSH config file and the computer_configure dictionary,
+        since the SSH config file is generated from the computer_configure dictionary in `SshComputerSetup._write_ssh_config`.
+        """
         sshcfg = aiida_ssh_plugin.parse_sshconfig(self.hostname.value)
         authparams = {
             "port": int(sshcfg.get("port", 22)),
@@ -871,10 +883,19 @@ class AiidaComputerSetup(ipw.VBox):
                 message = "SSH username is not provided"
                 raise RuntimeError(message) from exc
 
-        if "proxycommand" in sshcfg:
-            authparams["proxy_command"] = sshcfg["proxycommand"]
-        elif "proxyjump" in sshcfg:
-            authparams["proxy_jump"] = sshcfg["proxyjump"]
+        if "proxy_jump" in self.computer_configure:
+            authparams["proxy_jump"] = self.computer_configure["proxy_jump"]
+
+        if "proxy_command" in self.computer_configure:
+            authparams["proxy_command"] = self.computer_configure["proxy_command"]
+
+        if "key_filename" in self.computer_configure:
+            authparams["key_filename"] = os.path.expanduser(
+                self.computer_configure["key_filename"]
+            )
+
+        if "key_policy" in self.computer_configure:
+            authparams["key_policy"] = self.computer_configure["key_policy"]
 
         computer.configure(user=user, **authparams)
         return True

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import copy
 import enum
-import os
 import re
 import subprocess
 import threading
@@ -841,12 +840,11 @@ class AiidaComputerSetup(ipw.VBox):
     def _configure_computer_ssh(self, computer: orm.Computer, user: orm.User):
         """Configure the computer with SSH transport
 
-        There are three sources of authparams information:
+        There are three sources of authparams information ordered by priority increase:
+        - the default values
         - the SSH config file
         - the computer_configure dictionary
-        - the default values
 
-        Priority is given to the computer_configure dictionary, then to the SSH config file, then to the default values.
         At the moment, there is no overlap between the SSH config file and the computer_configure dictionary.
 
         The proxyjump and proxycommend can be read from both the SSH config file and the computer_configure dictionary,
@@ -856,8 +854,8 @@ class AiidaComputerSetup(ipw.VBox):
         authparams = {
             "port": int(sshcfg.get("port", 22)),
             "look_for_keys": True,
-            "key_filename": os.path.expanduser(
-                sshcfg.get("identityfile", ["~/.ssh/id_rsa"])[0]
+            "key_filename": str(
+                Path(sshcfg.get("identityfile", ["~/.ssh/id_rsa"])[0]).expanduser()
             ),
             "timeout": 60,
             "allow_agent": True,
@@ -890,8 +888,8 @@ class AiidaComputerSetup(ipw.VBox):
             authparams["proxy_command"] = self.computer_configure["proxy_command"]
 
         if "key_filename" in self.computer_configure:
-            authparams["key_filename"] = os.path.expanduser(
-                self.computer_configure["key_filename"]
+            authparams["key_filename"] = str(
+                Path(self.computer_configure["key_filename"]).expanduser()
             )
 
         if "key_policy" in self.computer_configure:

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -1,4 +1,3 @@
-import os
 import re
 from pathlib import Path
 
@@ -130,8 +129,8 @@ def test_aiida_computer_setup_widget_default():
     assert computer.configure().get_auth_params()["proxy_jump"] == "ela.cscs.ch"
     assert computer.configure().get_auth_params()["safe_interval"] == 10
     assert computer.configure().get_auth_params()["use_login_shell"] is True
-    assert computer.configure().get_auth_params()["key_filename"] == os.path.expanduser(
-        "~/.ssh/cscs-key"
+    assert computer.configure().get_auth_params()["key_filename"] == str(
+        Path("~/.ssh/cscs-key").expanduser()
     )
     assert computer.configure().get_auth_params()["key_policy"] == "AutoAddPolicy"
 

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 
@@ -113,6 +114,8 @@ def test_aiida_computer_setup_widget_default():
         "proxy_jump": "ela.cscs.ch",
         "safe_interval": 10,
         "use_login_shell": True,
+        "key_filename": "~/.ssh/cscs-key",
+        "key_policy": "AutoAddPolicy",
         "username": "aiida",
     }
 
@@ -124,6 +127,13 @@ def test_aiida_computer_setup_widget_default():
     computer = orm.load_computer("daint")
     assert computer.label == "daint"
     assert computer.hostname == "daint.cscs.ch"
+    assert computer.configure().get_auth_params()["proxy_jump"] == "ela.cscs.ch"
+    assert computer.configure().get_auth_params()["safe_interval"] == 10
+    assert computer.configure().get_auth_params()["use_login_shell"] is True
+    assert computer.configure().get_auth_params()["key_filename"] == os.path.expanduser(
+        "~/.ssh/cscs-key"
+    )
+    assert computer.configure().get_auth_params()["key_policy"] == "AutoAddPolicy"
 
     # Reset the widget and check that a few attributes are reset.
     widget.computer_setup = {}


### PR DESCRIPTION
There are some values for authinfo setting that are hardcoded. It should be able to be set from computer-configure dict. This is required by the CSCS MFA configure setup. The key filename is set in configure to `cscs-key` but not passed to the `AuthInfo`.