### PR TITLE
Use GHCR image to avoid dockerhub pull rate limit

### DIFF
--- a/tests_notebooks/docker-compose.yml
+++ b/tests_notebooks/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3.4'
 services:
 
     aiidalab:
-        image: aiidalab/full-stack:${TAG:-latest}
+        image: ghcr.io/aiidalab/full-stack:${TAG:-latest}
         environment:
             RMQHOST: messaging
             TZ: Europe/Zurich


### PR DESCRIPTION
I guess the integration notebook tests failed because of [Docker Hub rate limit]((https://docs.docker.com/docker-hub/download-rate-limit/)).
Use the image from ghrc can help.