### PR TITLE
Replace optimade-client with ipyoptimade

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -157,7 +157,7 @@ class OptimadeQueryWidget(ipw.VBox):
         **kwargs,
     ) -> None:
         try:
-            from optimade_client import default_parameters, query_filter, query_provider
+            from ipyoptimade import default_parameters, query_filter, query_provider
         except ImportError:
             super().__init__(
                 [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ filterwarnings = [
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',
     'ignore::DeprecationWarning:ase.atoms',
-    # TODO: This comes from a transitive dependency of optimade_client
+    # TODO: This comes from a transitive dependency of ipyoptimade
     # Remove this when this issue is addressed:
     # https://github.com/CasperWA/ipywidgets-extended/issues/85
     'ignore::DeprecationWarning:ipywidgets_extended',

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ dev =
     selenium~=4.7.0
     webdriver-manager~=3.8
 optimade =
-    optimade-client==2022.9.19
+    ipyoptimade~=0.1
 smiles =
     rdkit>=2021.09.2
     scikit-learn~=1.0.0


### PR DESCRIPTION
~~Able to install with aiida-core v2.5.0 but turns out there are quite a lot things we need to fix.~~

As discussed (see the thread in this PR), will only replace the optimade-client with `ipyoptimade~=0.1` which is the version right after the migration without the support to the pydantic v2 (which comes in version `v0.2`).