### PR TITLE
Drop support for py38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         strategy:
             matrix:
                 tag: [latest]
-                python-version: ['3.8', '3.9', '3.10']
+                python-version: ['3.9', '3.10']
             fail-fast: false
 
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       rev: v3.15.0
       hooks:
           - id: pyupgrade
-            args: [--py37-plus]
+            args: [--py39-plus]
 
     - repo: https://github.com/kynan/nbstripout
       rev: 0.6.1

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -1,6 +1,5 @@
 """Widgets to work with AiiDA nodes."""
 import functools
-import typing
 
 import ipytree
 import ipywidgets as ipw
@@ -93,9 +92,7 @@ class AiidaOutputsTreeNode(ipytree.Node):
     icon = tl.Unicode("folder").tag(sync=True)
     disabled = tl.Bool(True).tag(sync=True)
 
-    def __init__(
-        self, name, parent_pk, namespaces: typing.Tuple[str, ...] = (), **kwargs
-    ):
+    def __init__(self, name, parent_pk, namespaces: tuple[str, ...] = (), **kwargs):
         self.parent_pk = parent_pk
         self.nodes_registry = {}
         self.namespaces = namespaces

--- a/aiidalab_widgets_base/utils/__init__.py
+++ b/aiidalab_widgets_base/utils/__init__.py
@@ -1,7 +1,7 @@
 """Some utility functions used acrross the repository."""
 import threading
 from enum import Enum
-from typing import Any, Tuple
+from typing import Any
 
 import ipywidgets as ipw
 import more_itertools as mit
@@ -200,7 +200,7 @@ def wrap_message(message, level=MessageLevel.INFO):
     """
 
 
-def ase2spglib(ase_structure: Atoms) -> Tuple[Any, Any, Any]:
+def ase2spglib(ase_structure: Atoms) -> tuple[Any, Any, Any]:
     """
     Convert ase Atoms instance to spglib cell in the format defined at
     https://spglib.github.io/spglib/python-spglib.html#crystal-structure-cell

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     nglview~=3.0
     spglib>=1.14,<3
     vapory~=0.1.2
-python_requires = >=3.8
+python_requires = >=3.9
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
The support for Python versions follows the same timeline as that of numpy, defined in NEP 029. According to that schema, Python 3.8 is no longer support as of April 14 2023 and so official support is also dropped in AWB.