### PR TITLE
Integrate with WEAS viewer.

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -187,11 +187,11 @@ class StructureManagerWidget(ipw.VBox):
                     )
                 if editor.has_trait("selection"):
                     tl.link((editor, "selection"), (self.viewer, "selection"))
-                if editor.has_trait("camera_orientation"):
-                    tl.dlink(
-                        (self.viewer._viewer, "_camera_orientation"),
-                        (editor, "camera_orientation"),
-                    )
+                # if editor.has_trait("camera_orientation"):
+                #     tl.dlink(
+                #         (self.viewer._viewer, "_camera_orientation"),
+                #         (editor, "camera_orientation"),
+                #     )
             return editors_tab
         return None
 
@@ -337,7 +337,6 @@ class StructureManagerWidget(ipw.VBox):
         This function enables/disables `btn_store` widget if structure is provided/set to None.
         Also, the function sets `structure_node` trait to the selected node type.
         """
-
         if not self.structure_set_by_undo:
             self.history.append(change["new"])
 

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -37,7 +37,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import aiidalab_widgets_base as awb"
+    "import aiidalab_widgets_base as awb\n",
+    "import weas_widget\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer = weas_widget.WeasWidget()"
    ]
   },
   {
@@ -71,6 +81,15 @@
     "# Remove 'Store in AiiDA' button\n",
     "# widget = StructureManagerWidget(importers = [(\"From computer\", StructureUploadWidget())], storable=False)\n",
     "display(widget)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "viewer"
    ]
   }
  ],

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -47,7 +47,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = weas_widget.WeasWidget()"
+    "guiConfig={\"enabled\": True,\n",
+    "           \"components\": {\"atomsControl\": True,\n",
+    "                          \"colorControl\": True,\n",
+    "                          \"buttons\": True,},\n",
+    "           \"buttons\": {\"fullscreen\": True,\n",
+    "                       \"download\": True,\n",
+    "                       \"measurement\": True,\n",
+    "                       }\n",
+    "         }\n",
+    "viewer = weas_widget.WeasWidget(guiConfig=guiConfig)"
    ]
   },
   {

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "import aiidalab_widgets_base as awb\n",
-    "import weas_widget\n"
+    "import weas_widget"
    ]
   },
   {
@@ -73,6 +73,7 @@
     "        awb.BasicStructureEditor(title=\"Basic Editor\"),\n",
     "        awb.BasicCellEditor(title=\"Basic Cell Editor\"),\n",
     "    ],\n",
+    "    viewer=viewer,\n",
     ")\n",
     "# widget = StructureUploadWidget()\n",
     "# Enforce node format to be CifData:\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     nglview~=3.0
     spglib>=1.14,<3
     vapory~=0.1.2
+    weas-widget
 python_requires = >=3.9
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Requires https://github.com/superstar54/weas-widget/pull/22.


Here is the way to test it:

1. Enter AiiDAlab's terminal, cd into the `~/apps/` folder
2. Clone the awb repository, and enter it: `cd aiidalab-widgets-base`
3. Switch to the `feature/weas-viewer-integration` branch
4. Pip install it: `pip install --user -e .`
5. Go to another location and git clone [my fork](https://github.com/yakutovicha/weas-widget.git) of the weas-widget.
6. Enter the folder and switch to the `feature/integrate-with-structuremanager-widget` branch.
7. Pip install it: `pip install --user -e .`
8. Open `File Manager` in AiiDAlab and enter the `apps/aiidalab-widgets-base/notebooks` folder
9. Launch `structures.ipynb` and execute its cells.

Problems:

1. When integrated with awb's `StructureManager` the control icons look weird:
![image](https://github.com/aiidalab/aiidalab-widgets-base/assets/13118485/5d0980f4-7708-4d0c-bfa0-1a90efb4ab4c)

2. When uploading a new structure with the `StructureManager`, the weas viewer doesn't show it. The only way for it to work is to launch a viewer in a separate cell and execute it:

![image](https://github.com/aiidalab/aiidalab-widgets-base/assets/13118485/c3de4783-e242-42a8-8875-b104dc8d49fb)

