### PR TITLE
Remove the push and tag capability of bumpver

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,8 +83,6 @@ current_version = "v2.1.0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True
-tag = True
-push = True
 
 [bumpver:file_patterns]
 aiidalab_widgets_base/__init__.py =


### PR DESCRIPTION
The push and tag can be triggered manually by hand. 
The https://github.com/aiidalab/aiidalab-widgets-base/blob/master/.github/workflows/publish.yml will manage the publish to PyPI.