### PR TITLE
New publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,30 +14,7 @@ concurrency:
 
 jobs:
 
-    pre-commit:
-    # Adapted from: https://github.com/CasperWA/voila-optimade-client
-
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Setup Python
-              uses: actions/setup-python@v5
-              with:
-                  python-version: '3.10'
-                  cache: pip
-                  cache-dependency-path: |
-                      .pre-commit-config.yaml
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
-
-            - uses: pre-commit/action@v3.0.1
-
     test-notebooks:
-
-        needs: [pre-commit]
 
         strategy:
             matrix:
@@ -102,8 +79,6 @@ jobs:
                   if-no-files-found: error
 
     test-package:
-
-        needs: [pre-commit]
 
         strategy:
             matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,9 +47,7 @@ jobs:
     publish-test:
 
         name: Build and publish on TestPyPI
-        if: >
-            startsWith(github.ref, 'refs/heads/release/') ||
-            startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/heads/release/')
 
         needs: [build]
         runs-on: ubuntu-latest
@@ -67,7 +65,6 @@ jobs:
 
             - name: Publish distribution on Test PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
-              if: startsWith(github.ref, 'refs/heads/release/')
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}
@@ -77,7 +74,7 @@ jobs:
     publish:
 
         name: Build and publish on PyPI
-        if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags/v')
 
         needs: [build]
         runs-on: ubuntu-latest
@@ -94,16 +91,15 @@ jobs:
                   name: release
                   path: dist/
 
-            - uses: softprops/action-gh-release@v0.1.15
-              name: Create release
-              if: startsWith(github.ref, 'refs/tags/v')
-              with:
-                  files: |
-                      dist/*
-                  generate_release_notes: true
-
             - name: Publish distribution on PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}
+
+            - uses: softprops/action-gh-release@v0.1.15
+              name: Create release
+              with:
+                  files: |
+                      dist/*
+                  generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,8 @@ jobs:
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}
-                  repository_url: https://test.pypi.org/legacy/
-                  skip_existing: true
+                  repository-url: https://test.pypi.org/legacy/
+                  skip-existing: true
 
     publish:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,12 @@
 name: Publish on Test PyPI and PyPI
 
 on:
-    push:
+    pull_request:
         branches:
-      # Commits pushed to release/ branches are published on Test PyPI if they
-      # have a new version number.
+        # Commits pushed to release/ branches are published on Test PyPI if they
+        # have a new version number.
             - release/**
-        tags:
-      # Tags that start with the "v" prefix are published on PyPI.
-            - v*
+    release:
 
 jobs:
 
@@ -47,7 +45,7 @@ jobs:
     publish-test:
 
         name: Build and publish on TestPyPI
-        if: startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'aiidalab'
+        if: github.repository_owner == 'aiidalab'
 
         needs: [build]
         runs-on: ubuntu-latest
@@ -76,7 +74,7 @@ jobs:
         name: Build and publish on PyPI
         if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'aiidalab'
 
-        needs: [build]
+        needs: [build, publish-test]
         runs-on: ubuntu-latest
 
         environment:
@@ -96,10 +94,3 @@ jobs:
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}
-
-            - uses: softprops/action-gh-release@v0.1.15
-              name: Create release
-              with:
-                  files: |
-                      dist/*
-                  generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
     publish-test:
 
         name: Build and publish on TestPyPI
-        if: startsWith(github.ref, 'refs/heads/release/')
+        if: startsWith(github.ref, 'refs/heads/release/') && github.repository_owner == 'aiidalab'
 
         needs: [build]
         runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
     publish:
 
         name: Build and publish on PyPI
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'aiidalab'
 
         needs: [build]
         runs-on: ubuntu-latest


### PR DESCRIPTION
The biggest fix here is to stop a release to PyPI if the tag does not start with `v`.

We now also automatically skip the publish if we are in a fork (it would fail anyway since the secrets are not available on forks).
I've verified the new behaviour on my fork.