### PR TITLE
CI: Add CODECOV_TOKEN secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,3 +146,4 @@ jobs:
               uses: codecov/codecov-action@v4
               with:
                   flags: python-${{ matrix.python-version }}
+                  token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Starting from `codecov-action@v4`, Codecov requires setting up a `CODECOV_TOKEN`, otherwise the upload will fail. Note that forks don't require this token, only PRs from the original repo so forks don't need (and don't have) access to this token.

I've generated a global token for aiidalab org at https://app.codecov.io/account/gh/aiidalab/org-upload-token

![image](https://github.com/aiidalab/aiidalab-widgets-base/assets/9539441/f2301b3d-0036-468e-9190-60b3379d3a26)

I then I added the token as an organization-wide secret on Github so that we don't have to configure it on every repo.

https://github.com/organizations/aiidalab/settings/secrets/actions

![image](https://github.com/aiidalab/aiidalab-widgets-base/assets/9539441/c2a436fa-d335-436e-98e6-42945562574e)

