### PR TITLE
Only trigger publish on release.published event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         # before it is pushed to the actual PyPI index.
             - release/**
     release:
-        published:
+        types: [published]
 
 jobs:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,11 @@ on:
     pull_request:
         branches:
         # Commits pushed to release/ branches are published on Test PyPI if they
-        # have a new version number.
+        # have a new version number. This allows the maintainer to check the release
+        # before it is pushed to the actual PyPI index.
             - release/**
     release:
+        published:
 
 jobs:
 


### PR DESCRIPTION
We noticed that making a release triggered multiple different `release` events: `created`, `prereleased`, `published`. So we need to tweak the workflow file so that the workflow only run for the `release.publish` event.

https://github.com/aiidalab/aiidalab-widgets-base/actions?query=event%3Arelease

Per GHA docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

EDIT: ~~I am not sure if the fix here works, need to test on another repo. Marking as draft for now~~

EDIT2: Never mind, turns out I can't read the docs properly. I fixed the syntax and checked on my repo, this seems to work correctly now.


