### PR TITLE
Bump uv + minor CI cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
               run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Install package with uv
+              if: false
               run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
                   }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,6 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: pip
-                  cache-dependency-path: |
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
 
             - name: Install uv
               run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
                       **/requirements*.txt
 
             - name: Install uv
-              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
               # Notebook tests happen in the container, here we only need to install
               # the pytest-docker dependency. Unfortunately, pip does not allow to
@@ -114,7 +114,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
             - name: Install package with uv
               run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,11 @@ jobs:
                       **/pyproject.toml
                       **/requirements*.txt
 
+            - name: Install uv
+              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
             - name: Install package
-              run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --system -e ".[dev,smiles,optimade]" aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,25 +109,8 @@ jobs:
             - name: Install uv
               run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-            - name: Install package with pip
-              run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
-
-            - name: Print versions and paths (before uv)
-              run: |
-                  which pytest && which python
-                  python -c "import sys; print(sys.version); print(sys.modules)"
-                  python -c "import site; print(site.getsitepackages())"
-
             - name: Install package with uv
-              if: true
-              run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
-                  }}
-
-            - name: Print versions and paths (after uv)
-              run: |
-                  which pytest && which python
-                  python -c "import sys; print(sys.version); print(sys.modules)"
-                  python -c "import site; print(site.getsitepackages())"
+              run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
               run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
-              run: python -m pytest -v tests --cov
+              run: pytest -sv tests --cov
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,10 @@ jobs:
             - name: Install uv
               run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
-            - name: Install package
+            - name: Install package with pip
+              run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
+
+            - name: Install package with uv
               run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.22/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.24/uv-installer.sh | sh
 
             - name: Install package test dependencies
               # Notebook tests happen in the container, here we only need to install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
               # Notebook tests happen in the container, here we only need to install
               # the pytest-docker dependency. Unfortunately, uv/pip does not allow to
               # only install [dev] dependencies so we end up installing all the rest as well.
-              run: uv pip install --system -e .[dev]
+              run: uv pip install --system .[dev]
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
@@ -109,7 +109,7 @@ jobs:
                   python-version: ${{ matrix.python-version }}
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.24/uv-installer.sh | sh
 
             - name: Install package
             # NOTE: uv (unlike pip) does not compile python to bytecode after install.
@@ -118,7 +118,7 @@ jobs:
             # Ideally, these would be fixed, but vapory is largely unmaintained,
             # so here we simply keep the pip behaviour with the --compile flag.
             # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514
-              run: uv pip install --compile --system -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --compile --system .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.11', '3.12']
-                aiida-core-version: [2.2.2, 2.5.0]          # test on the latest and the oldest supported version
+                python-version: ['3.9', '3.10', '3.11']
+                aiida-core-version: [2.2.2]            # test on the latest and the oldest supported version
             fail-fast: false
 
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
               run: uv pip install --compile --system -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
-              run: pytest -sv tests --cov
+              run: pytest -v tests --cov
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
               run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Install package with uv
-              run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
               run: curl -LsSf https://astral.sh/uv/install.sh | sh
 
             - name: Install package
-              run: uv pip install --system -e ".[dev,smiles,optimade]" aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
               # the pytest-docker dependency. Unfortunately, pip does not allow to
               # only install [dev] dependencies so we end up installing all the rest as well.
             - name: Install package dev dependencies with uv
-              run: uv pip install --system "aiidalab_widgets_base[dev] @ ." aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --compile --system "aiidalab_widgets_base[dev] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
@@ -117,7 +117,7 @@ jobs:
               run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
             - name: Install package with uv
-              run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --compile --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -sv tests --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,14 @@ jobs:
                       **/pyproject.toml
                       **/requirements*.txt
 
-            - name: Install package test dependencies
+            - name: Install uv
+              run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
               # Notebook tests happen in the container, here we only need to install
               # the pytest-docker dependency. Unfortunately, pip does not allow to
               # only install [dev] dependencies so we end up installing all the rest as well.
-              run: pip install -e .[dev]
+            - name: Install package dev dependencies with uv
+              run: uv pip install --system "aiidalab_widgets_base[dev] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
                   python -c "import site; print(site.getsitepackages())"
 
             - name: Install package with uv
-              if: false
+              if: true
               run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
                   }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,10 @@ jobs:
               run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
-              run: pytest -v tests --cov
+              run: |
+                  which pytest
+                  which python
+                  python -m pytest -v tests --cov
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,15 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: pip
-                  cache-dependency-path: |
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
 
             - name: Install uv
               run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
               # Notebook tests happen in the container, here we only need to install
-              # the pytest-docker dependency. Unfortunately, pip does not allow to
+              # the pytest-docker dependency. Unfortunately, uv/pip does not allow to
               # only install [dev] dependencies so we end up installing all the rest as well.
-            - name: Install package dev dependencies with uv
-              run: uv pip install --compile --system "aiidalab_widgets_base[dev] @ ." aiida-core==${{ matrix.aiida-core-version }}
+            - name: Install dev dependencies with uv
+              run: uv pip install --system "aiidalab_widgets_base[dev] @ ."
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
               run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Install package with uv
-              run: uv pip install --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
+              run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
+                  }}
 
             - name: Run pytest
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,9 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.10', '3.11']
-                aiida-core-version: [2.2.2]            # test on the latest and the oldest supported version
+                python-version: ['3.9', '3.10']
+                # Test on the latest and oldest supported version
+                aiida-core-version: [2.2.2, 2.4.3]
             fail-fast: false
 
         runs-on: ubuntu-latest
@@ -116,8 +117,7 @@ jobs:
               run: uv pip install --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
-              run: |
-                  python -m pytest -v tests --cov
+              run: python -m pytest -v tests --cov
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,15 +112,27 @@ jobs:
             - name: Install package with pip
               run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
-            - name: Install package with uv
-              if: false
-              run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
-                  }}
-
-            - name: Run pytest
+            - name: Print versions and paths (before uv)
               run: |
                   which pytest
                   which python
+                  python -c "import sys; print(sys.version); print(sys.modules)"
+                  python -c "import site; site.getsitepackages()"
+
+            - name: Install package with uv
+              if: true
+              run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
+                  }}
+
+            - name: Print versions and paths (after uv)
+              run: |
+                  which pytest
+                  which python
+                  python -c "import sys; print(sys.version); print(sys.modules)"
+                  python -c "import site; site.getsitepackages()"
+
+            - name: Run pytest
+              run: |
                   python -m pytest -v tests --cov
 
             - name: Upload coverage reports to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.11', '3.12']
-                aiida-core-version: [2.2.2, 2.4.3]          # test on the latest and the oldest supported version
+                aiida-core-version: [2.2.2, 2.5.0]          # test on the latest and the oldest supported version
             fail-fast: false
 
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
                   python -c "import site; print(site.getsitepackages())"
 
             - name: Install package with uv
-              if: true
+              if: false
               run: uv --version && uv pip install -v --reinstall --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version
                   }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,9 @@ jobs:
 
             - name: Print versions and paths (before uv)
               run: |
-                  which pytest
-                  which python
+                  which pytest && which python
                   python -c "import sys; print(sys.version); print(sys.modules)"
-                  python -c "import site; site.getsitepackages()"
+                  python -c "import site; print(site.getsitepackages())"
 
             - name: Install package with uv
               if: true
@@ -126,10 +125,9 @@ jobs:
 
             - name: Print versions and paths (after uv)
               run: |
-                  which pytest
-                  which python
+                  which pytest && which python
                   python -c "import sys; print(sys.version); print(sys.modules)"
-                  python -c "import site; site.getsitepackages()"
+                  python -c "import site; print(site.getsitepackages())"
 
             - name: Run pytest
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 ---
-# Run basic tests for this app on the latest aiidalab-docker image.
+# Run unit tests and notebook tests on the latest aiidalab-docker image.
 
-name: continuous-integration
+name: CI
 
-on: [push, pull_request]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
 
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -42,10 +46,9 @@ jobs:
                       **/requirements*.txt
 
             - name: Install package test dependencies
-              # Test test will actually happened in the container, here only need to install
-              # the pytest-docker dependency.
-              # To add the dependencies to the container, we need to add them to the
-              # installation command in the `test_notebooks/conftest.py`.
+              # Notebook tests happen in the container, here we only need to install
+              # the pytest-docker dependency. Unfortunately, pip does not allow to
+              # only install [dev] dependencies so we end up installing all the rest as well.
               run: pip install -e .[dev]
 
             - name: Set jupyter token env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.10']
+                python-version: ['3.11', '3.12']
                 aiida-core-version: [2.2.2, 2.4.3]          # test on the latest and the oldest supported version
             fail-fast: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,6 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    'ignore::DeprecationWarning:vapory',
-    'ignore::DeprecationWarning:CifFile',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 filterwarnings = [
+    'error',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,10 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    'ignore:::vapory',
-    'ignore:::CifFile',
+    'ignore::SyntaxError:vapory',
+    'ignore::DeprecationWarning:vapory',
+    'ignore::SyntaxError:CifFile',
+    'ignore::DeprecationWarning:CifFile',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ filterwarnings = [
     'ignore::DeprecationWarning:jupyter_client',
     'ignore::DeprecationWarning:selenium',
     'ignore::DeprecationWarning:pytest_selenium',
+    'ignore:::vapory',
+    'ignore:::CifFile',
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    'error',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
-    'ignore::SyntaxError:vapory',
     'ignore::DeprecationWarning:vapory',
-    'ignore::SyntaxError:CifFile',
     'ignore::DeprecationWarning:CifFile',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    'ignore:::vapory',
+    'ignore:::CifFile',
     'ignore::DeprecationWarning:bokeh.core.property.primitive',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',
@@ -17,20 +19,13 @@ filterwarnings = [
     # https://github.com/CasperWA/ipywidgets-extended/issues/85
     'ignore::DeprecationWarning:ipywidgets_extended',
     'ignore:metadata.*traitlets.traitlets.Unicode object:DeprecationWarning:traitlets',
-    # For some reason we get this error, perhaps because we do
-    # not unload the AiiDA profile? Let's ignore this for now.
-    # E pytest.PytestUnraisableExceptionWarning: Exception ignored in: <function Popen.__del__>
-    # E Traceback (most recent call last):
-    # E   File "/opt/conda/lib/python3.9/subprocess.py", line 1052, in __del__
-    # E     _warn("subprocess %s is still running" % self.pid,
-    # E ResourceWarning: subprocess 382685 is still running
+    # For some reason we get this error, see
+    # https://github.com/aiidalab/aiidalab-widgets-base/issues/551
     'ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning:_pytest',
     'ignore::DeprecationWarning:pytest_html',
     'ignore::DeprecationWarning:jupyter_client',
     'ignore::DeprecationWarning:selenium',
     'ignore::DeprecationWarning:pytest_selenium',
-    'ignore:::vapory',
-    'ignore:::CifFile',
 ]
 
 [tool.ruff]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,7 @@ zip_safe = False
 
 [options.extras_require]
 dev =
-    bumpver~=2023.1129
     pgtest~=1.3
-    pre-commit~=3.5
     # NOTE: pytest-selenium currently incompatible with pytest>=7.2
     # Maybe could be made to work by installing 'py' dependency, see:
     # https://docs.pytest.org/en/7.4.x/changelog.html#pytest-7-2-0-2022-10-23

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ optimade =
     ipyoptimade~=0.1
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=1.1
+    scikit-learn~=1.0.0
 docs =
     sphinx
     sphinx-design

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ optimade =
     ipyoptimade~=0.1
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=1.0.0
+    scikit-learn~=1.1
 docs =
     sphinx
     sphinx-design

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,14 @@ zip_safe = False
 
 [options.extras_require]
 dev =
+    bumpver~=2023.1129
+    pre-commit~=3.5
+    bumpver
     pgtest~=1.3
     # NOTE: pytest-selenium currently incompatible with pytest>=7.2
     # Maybe could be made to work by installing 'py' dependency, see:
     # https://docs.pytest.org/en/7.4.x/changelog.html#pytest-7-2-0-2022-10-23
-    pytest~=7.1.0
+    pytest~=7.2
     pytest-cov~=4.0
     pytest-docker~=2.0
     pytest-selenium~=4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,13 +43,12 @@ zip_safe = False
 [options.extras_require]
 dev =
     bumpver~=2023.1129
-    pre-commit~=3.5
-    bumpver
     pgtest~=1.3
+    pre-commit~=3.5
     # NOTE: pytest-selenium currently incompatible with pytest>=7.2
     # Maybe could be made to work by installing 'py' dependency, see:
     # https://docs.pytest.org/en/7.4.x/changelog.html#pytest-7-2-0-2022-10-23
-    pytest~=7.2
+    pytest~=7.1.0
     pytest-cov~=4.0
     pytest-docker~=2.0
     pytest-selenium~=4.0


### PR DESCRIPTION
- New uv version let's us drop the editable install in the CI. 
- Don't trigger CI on both PRs and Push when the branch is pushed to origin repo
- shorten the CI workflow name so that it is displayed in full on GitHub

![image](https://github.com/aiidalab/aiidalab-widgets-base/assets/9539441/62526895-a51c-403f-82eb-837e4360ff14)
