### PR TITLE
CI: Use uv installer instead of pip (take 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
               # the pytest-docker dependency.
               # To add the dependencies to the container, we need to add them to the
               # installation command in the `test_notebooks/conftest.py`.
-              run: uv pip install --system "aiidalab_widgets_base[dev] @ ."
+              run: uv pip install --system -e .[dev]
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
@@ -114,7 +114,7 @@ jobs:
             # Ideally, these would be fixed, but vapory is largely unmaintained,
             # so here we simply keep the pip behaviour with the --compile flag.
             # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514
-              run: uv pip install --compile --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --compile --system -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,18 +35,16 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: pip
-                  cache-dependency-path: |
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
+
+            - name: Install uv
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
             - name: Install package test dependencies
               # Test test will actually happened in the container, here only need to install
               # the pytest-docker dependency.
               # To add the dependencies to the container, we need to add them to the
               # installation command in the `test_notebooks/conftest.py`.
-              run: pip install -e .[dev]
+              run: uv pip install --system "aiidalab_widgets_base[dev] @ ."
 
             - name: Set jupyter token env
               run: echo "JUPYTER_TOKEN=$(openssl rand -hex 32)" >> $GITHUB_ENV
@@ -105,14 +103,18 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.python-version }}
-                  cache: pip
-                  cache-dependency-path: |
-                      **/setup.cfg
-                      **/pyproject.toml
-                      **/requirements*.txt
+
+            - name: Install uv
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.21/uv-installer.sh | sh
 
             - name: Install package
-              run: pip install -e .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
+            # NOTE: uv (unlike pip) does not compile python to bytecode after install.
+            # This uncovered a lot of SyntaxError(s) in the vapory package,
+            # since pip swallows these by default (WTH?).
+            # Ideally, these would be fixed, but vapory is largely unmaintained,
+            # so here we simply keep the pip behaviour with the --compile flag.
+            # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514
+              run: uv pip install --compile --system "aiidalab_widgets_base[dev,smiles,optimade] @ ." aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov


### PR DESCRIPTION
[uv](https://github.com/astral-sh/uv/issues/2155l) is the new cool kid in the town of Python packaging, from the creators of ruff. It currently serves as a (much) faster drop-in replacement for pip. 

For AWB, uv _without_ cache runs in ~10s, compared to 1m10s for pip **with** cache. :exploding_head: So overall speedup around 30% for our workflows.