### PR TITLE
Build NodeTree on demand

### DIFF
--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -189,9 +189,19 @@ class NodesTreeWidget(ipw.Output):
                 name = calc_info(node)
             else:
                 name = str(node)
-        return cls.NODE_TYPE.get(type(node), UnknownTypeTreeNode)(
+        tree_node = cls.NODE_TYPE.get(type(node), UnknownTypeTreeNode)(
             pk=node.pk, name=name, **kwargs
         )
+        # Set the style based on the process state of the node
+        if isinstance(node, orm.ProcessNode):
+            process_state = (
+                engine.ProcessState.EXCEPTED if node.is_failed else node.process_state
+            )
+            tree_node.icon_style = cls.PROCESS_STATE_STYLE.get(
+                process_state, cls.PROCESS_STATE_STYLE_DEFAULT
+            )
+
+        return tree_node
 
     @classmethod
     def _find_called(cls, root):

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -141,6 +141,10 @@ class NodesTreeWidget(ipw.Output):
             display(self._tree)
 
     def _observe_tree_selected_nodes(self, change):
+        for node in change["new"]:
+            if hasattr(node, "pk"):
+                # find the selected node and build the tree from it, so that users can expand and explore the tree
+                self._build_tree(self.find_node(node.pk))
         return self.set_trait(
             "selected_nodes",
             tuple(
@@ -251,8 +255,8 @@ class NodesTreeWidget(ipw.Output):
 
     @classmethod
     def _build_tree(cls, root):
-        """Recursively build a tree nodes graph for a given tree node."""
-        root.nodes = [cls._build_tree(child) for child in cls._find_children(root)]
+        """Build a tree nodes graph for a given tree node."""
+        root.nodes = list(cls._find_children(root))
         return root
 
     @classmethod

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -67,7 +67,7 @@ class AiidaNodeTreeNode(ipytree.Node):
         super().__init__(name=name, **kwargs)
 
     @tl.default("opened")
-    def _default_openend(self):
+    def _default_opened(self):
         return True
 
 


### PR DESCRIPTION
Fix https://github.com/aiidalab/aiidalab-widgets-base/issues/584


This PR introduces the idea that: only build NodeTree on demand.
- do not build tree recursively, only show the top-level
- build the sub-tree when users select it, and expand it.


## Demo
Here I used the result of the IR/Raman plugin (from @AndresOrtegaGuerrero ) as a example. Before, it's almost impossible to load it in the NodeTree.

Using this PR:


https://github.com/aiidalab/aiidalab-widgets-base/assets/11457659/18aa487e-a6f6-429d-88b2-0b66ac9337ef


