### PR TITLE
Bump version v2.2.0a0 -> v2.2.0a1

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -117,4 +117,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "2.2.0a0"
+__version__ = "2.2.0a1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ docs =
     myst-nb
 
 [bumpver]
-current_version = "v2.2.0a0"
+current_version = "v2.2.0a1"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
I want to get a fix in #350 in a new alpha version.

Note, I've specifically opened this PR from my fork, to test @unkcpz observation that the tag from fork will not get transferred to origin when the PR is merged (which is most likely what will happen). In that case, I'll create the tag manually after merge.