### PR TITLE
Add pandas as direct dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     nglview~=3.0
     spglib>=1.14,<3
     vapory~=0.1.2
+    pandas~=2.1
 python_requires = >=3.9
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
pandas is used in several widgets to generate HTML tables. While the ultimate goal is to replace it with a lighterweight dependency, for now we declare it as direct dependecy. Previously, it was defined only transitively via `optimade_client`, which is now turned into optional `optimade` extras.

Closes #588 
