### PR TITLE
Do not add auxiliary cell to uploaded/generated gas phase structures 

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -375,9 +375,14 @@ class StructureUploadWidget(ipw.VBox):
     )
 
     def __init__(
-        self, title="", description="Upload Structure", allow_trajectories=False
+        self,
+        title="",
+        description="Upload Structure",
+        allow_trajectories=False,
+        add_auxiliary_cell=True,
     ):
         self.title = title
+        self.add_auxiliary_cell = add_auxiliary_cell
         self.file_upload = ipw.FileUpload(
             description=description, multiple=False, layout={"width": "initial"}
         )
@@ -400,14 +405,11 @@ class StructureUploadWidget(ipw.VBox):
         Checks if the ase Atoms object has a cell set,
         otherwise sets it to bounding box plus specified "vacuum" space
         """
-        if not ase_structure:
+        if not ase_structure or not self.add_auxiliary_cell:
             return None
 
         cell = ase_structure.cell
 
-        # TODO: Since AiiDA 2.0, zero cell is possible if PBC=false
-        # so we should honor that here and do not put artificial cell
-        # around gas phase molecules.
         if (
             np.linalg.norm(cell[0]) < 0.1
             or np.linalg.norm(cell[1]) < 0.1
@@ -763,8 +765,9 @@ class SmilesWidget(ipw.VBox):
 
     SPINNER = """<i class="fa fa-spinner fa-pulse" style="color:red;" ></i>"""
 
-    def __init__(self, title=""):
+    def __init__(self, title="", add_auxiliary_cell=True):
         self.title = title
+        self.add_auxiliary_cell = add_auxiliary_cell
         try:
             from rdkit import Chem  # noqa: F401
             from rdkit.Chem import AllChem  # noqa: F401
@@ -795,12 +798,10 @@ class SmilesWidget(ipw.VBox):
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""
         atoms = ase.Atoms(species, positions=positions, pbc=False)
-        atoms.cell = np.ptp(atoms.positions, axis=0) + 10
         atoms.center()
         # We're attaching this info so that it
         # can be later stored as an extra on AiiDA Structure node.
         atoms.info["smiles"] = smiles
-
         return atoms
 
     def _rdkit_opt(self, smiles, steps):
@@ -836,7 +837,10 @@ class SmilesWidget(ipw.VBox):
         positions = mol.GetConformer().GetPositions()
         natoms = mol.GetNumAtoms()
         species = [mol.GetAtomWithIdx(j).GetSymbol() for j in range(natoms)]
-        return self._make_ase(species, positions, smiles)
+        ase_mol = self._make_ase(species, positions, smiles)
+        if self.add_auxiliary_cell:
+            ase_mol.cell = np.ptp(ase_mol.positions, axis=0) + 10
+        return ase_mol
 
     def _mol_from_smiles(self, smiles, steps=1000):
         """Convert SMILES to ASE structure using RDKit"""

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -395,6 +395,32 @@ class StructureUploadWidget(ipw.VBox):
             children=[self.file_upload, supported_formats, self._status_message]
         )
 
+    def _validate_and_fix_ase_cell(self, ase_structure, vacuum_ang=10.0):
+        """
+        Checks if the ase Atoms object has a cell set,
+        otherwise sets it to bounding box plus specified "vacuum" space
+        """
+        if not ase_structure:
+            return None
+
+        cell = ase_structure.cell
+
+        # TODO: Since AiiDA 2.0, zero cell is possible if PBC=false
+        # so we should honor that here and do not put artificial cell
+        # around gas phase molecules.
+        if (
+            np.linalg.norm(cell[0]) < 0.1
+            or np.linalg.norm(cell[1]) < 0.1
+            or np.linalg.norm(cell[2]) < 0.1
+        ):
+            # if any of the cell vectors is too short, consider it faulty
+            # set cell as bounding box + vacuum_ang
+            bbox = np.ptp(ase_structure.positions, axis=0)
+            new_structure = ase_structure.copy()
+            new_structure.cell = bbox + vacuum_ang
+            return new_structure
+        return ase_structure
+
     def _on_file_upload(self, change=None):
         """When file upload button is pressed."""
         assert len(change["new"]) == 1, "Only single file upload is supported."
@@ -435,7 +461,10 @@ class StructureUploadWidget(ipw.VBox):
                 if self.allow_trajectories:
                     return TrajectoryData(
                         structurelist=[
-                            StructureData(ase=ase_struct) for ase_struct in structures
+                            StructureData(
+                                ase=self._validate_and_fix_ase_cell(ase_struct)
+                            )
+                            for ase_struct in structures
                         ]
                     )
                 else:
@@ -444,7 +473,7 @@ class StructureUploadWidget(ipw.VBox):
                         """
                     return None
 
-            return structures[0]
+            return self._validate_and_fix_ase_cell(structures[0])
 
 
 class StructureExamplesWidget(ipw.VBox):
@@ -728,7 +757,7 @@ class StructureBrowserWidget(ipw.VBox):
 
 
 class SmilesWidget(ipw.VBox):
-    """Convert SMILES into a 3D structure."""
+    """Convert SMILES into 3D structure."""
 
     structure = tl.Instance(ase.Atoms, allow_none=True)
 
@@ -743,9 +772,8 @@ class SmilesWidget(ipw.VBox):
             super().__init__(
                 [
                     ipw.HTML(
-                        "The SMILES widget requires the rdkit library, "
+                        "The SmilesWidget requires the rdkit library, "
                         "but the library was not found."
-                        "You can install it with <code>pip install rdkit<code>"
                     )
                 ]
             )
@@ -767,10 +795,12 @@ class SmilesWidget(ipw.VBox):
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""
         atoms = ase.Atoms(species, positions=positions, pbc=False)
+        atoms.cell = np.ptp(atoms.positions, axis=0) + 10
         atoms.center()
         # We're attaching this info so that it
         # can be later stored as an extra on AiiDA Structure node.
         atoms.info["smiles"] = smiles
+
         return atoms
 
     def _rdkit_opt(self, smiles, steps):

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -395,32 +395,6 @@ class StructureUploadWidget(ipw.VBox):
             children=[self.file_upload, supported_formats, self._status_message]
         )
 
-    def _validate_and_fix_ase_cell(self, ase_structure, vacuum_ang=10.0):
-        """
-        Checks if the ase Atoms object has a cell set,
-        otherwise sets it to bounding box plus specified "vacuum" space
-        """
-        if not ase_structure:
-            return None
-
-        cell = ase_structure.cell
-
-        # TODO: Since AiiDA 2.0, zero cell is possible if PBC=false
-        # so we should honor that here and do not put artificial cell
-        # around gas phase molecules.
-        if (
-            np.linalg.norm(cell[0]) < 0.1
-            or np.linalg.norm(cell[1]) < 0.1
-            or np.linalg.norm(cell[2]) < 0.1
-        ):
-            # if any of the cell vectors is too short, consider it faulty
-            # set cell as bounding box + vacuum_ang
-            bbox = np.ptp(ase_structure.positions, axis=0)
-            new_structure = ase_structure.copy()
-            new_structure.cell = bbox + vacuum_ang
-            return new_structure
-        return ase_structure
-
     def _on_file_upload(self, change=None):
         """When file upload button is pressed."""
         assert len(change["new"]) == 1, "Only single file upload is supported."
@@ -461,10 +435,7 @@ class StructureUploadWidget(ipw.VBox):
                 if self.allow_trajectories:
                     return TrajectoryData(
                         structurelist=[
-                            StructureData(
-                                ase=self._validate_and_fix_ase_cell(ase_struct)
-                            )
-                            for ase_struct in structures
+                            StructureData(ase=ase_struct) for ase_struct in structures
                         ]
                     )
                 else:
@@ -473,7 +444,7 @@ class StructureUploadWidget(ipw.VBox):
                         """
                     return None
 
-            return self._validate_and_fix_ase_cell(structures[0])
+            return structures[0]
 
 
 class StructureExamplesWidget(ipw.VBox):
@@ -757,7 +728,7 @@ class StructureBrowserWidget(ipw.VBox):
 
 
 class SmilesWidget(ipw.VBox):
-    """Convert SMILES into 3D structure."""
+    """Convert SMILES into a 3D structure."""
 
     structure = tl.Instance(ase.Atoms, allow_none=True)
 
@@ -772,8 +743,9 @@ class SmilesWidget(ipw.VBox):
             super().__init__(
                 [
                     ipw.HTML(
-                        "The SmilesWidget requires the rdkit library, "
+                        "The SMILES widget requires the rdkit library, "
                         "but the library was not found."
+                        "You can install it with <code>pip install rdkit<code>"
                     )
                 ]
             )
@@ -795,12 +767,10 @@ class SmilesWidget(ipw.VBox):
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""
         atoms = ase.Atoms(species, positions=positions, pbc=False)
-        atoms.cell = np.ptp(atoms.positions, axis=0) + 10
         atoms.center()
         # We're attaching this info so that it
         # can be later stored as an extra on AiiDA Structure node.
         atoms.info["smiles"] = smiles
-
         return atoms
 
     def _rdkit_opt(self, smiles, steps):

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -405,8 +405,11 @@ class StructureUploadWidget(ipw.VBox):
         Checks if the ase Atoms object has a cell set,
         otherwise sets it to bounding box plus specified "vacuum" space
         """
-        if not ase_structure or not self.add_auxiliary_cell:
+        if not ase_structure:
             return None
+
+        if not self.add_auxiliary_cell:
+            return ase_structure
 
         cell = ase_structure.cell
 

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -239,6 +239,12 @@ def test_smiles_widget():
     widget._on_button_pressed()
     assert isinstance(widget.structure, ase.Atoms)
     assert widget.structure.get_chemical_formula() == "CH4"
+    # By default, a rectangular cell is added (10 angstroms in each direction)
+    # but PBC is False
+    assert not any(widget.structure.pbc)
+    cell = widget.structure.cell
+    assert all(np.greater(np.diag(cell), [10, 10, 10]))
+    assert np.array_equal(cell.angles(), [90.0, 90.0, 90.0])
 
     # Regression test that we can generate 1-atom and 2-atom molecules
     widget.smiles.value = "[O]"
@@ -255,6 +261,23 @@ def test_smiles_widget():
     widget.smiles.value = "invalid"
     widget._on_button_pressed()
     assert widget.structure is None
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_smiles_widget_without_cell():
+    """Test the `SmilesWidget`."""
+    widget = awb.SmilesWidget(add_auxiliary_cell=False)
+    assert widget.structure is None
+
+    # Simulate the structure generation.
+    widget.smiles.value = "C"
+    widget._on_button_pressed()
+    assert isinstance(widget.structure, ase.Atoms)
+    assert widget.structure.get_chemical_formula() == "CH4"
+    # There should be no cell, which ASE represents with a zero cell
+    assert not any(widget.structure.pbc)
+    assert not np.any(widget.structure.cell)
+    assert not widget.structure.cell.volume
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -181,10 +181,11 @@ def test_structure_browser_widget(structure_data_object, monkeypatch):
     )
 
 
+@pytest.mark.parametrize("add_auxiliary_cell", (False, True))
 @pytest.mark.usefixtures("aiida_profile_clean")
-def test_structure_upload_widget():
+def test_structure_upload_widget(add_auxiliary_cell):
     """Test the `StructureUploadWidget`."""
-    widget = awb.StructureUploadWidget()
+    widget = awb.StructureUploadWidget(add_auxiliary_cell=add_auxiliary_cell)
     assert widget.structure is None
 
     # Simulate the structure upload.
@@ -205,6 +206,16 @@ def test_structure_upload_widget():
     assert isinstance(widget.structure, ase.Atoms)
     assert widget.structure.get_chemical_formula() == "Si2"
     assert np.all(widget.structure[0].position == [0, 0, 0])
+
+    if add_auxiliary_cell:
+        cell = widget.structure.cell
+        assert all(np.greater(np.diag(cell), [10, 10, 10]))
+        assert np.array_equal(cell.angles(), [90.0, 90.0, 90.0])
+    else:
+        # There should be no cell, which ASE represents with a zero cell
+        assert not any(widget.structure.pbc)
+        assert not np.any(widget.structure.cell)
+        assert not widget.structure.cell.volume
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")


### PR DESCRIPTION
`StructureUpload` and `SmilesWidget` currently automatically add a 10 Angstrom auxiliary cells to gas phase molecules. That's needed for plane wave codes, but is confusing and distracting for Quantum Chemistry codes such as ORCA.

This PR introduces a new parameter (`add_auxiliary_cell`) to these widgets to control this behaviour. The default is kept `True` for backwards compatibility (even though as a chemist (not material scientist) I am not happy about it :-D )