### PR TITLE
Run test publish workflow on push to release/ branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,11 @@
 name: Publish on (Test) PyPI
 
 on:
-    pull_request:
+    push:
+        # Commits pushed to release/ branches are published on Test PyPI
+        # if they have a new version number.
+        # If the version is the same, the worflow will still complete successfully,
+        # but the already published version on Test PyPI will not be updated.
         branches:
             - 'release/**'
     release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
 
     build:
 
+        name: Build package
         runs-on: ubuntu-latest
 
         steps:
@@ -47,7 +48,7 @@ jobs:
 
     publish-test:
 
-        name: Build and publish on TestPyPI
+        name: Publish on TestPyPI
         if: github.repository_owner == 'aiidalab'
 
         needs: [build]
@@ -74,7 +75,7 @@ jobs:
 
     publish:
 
-        name: Build and publish on PyPI
+        name: Publish on PyPI
         if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'aiidalab'
 
         needs: [build, publish-test]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,10 @@
 ---
-name: Publish on Test PyPI and PyPI
+name: Publish on (Test) PyPI
 
 on:
     pull_request:
+        branches:
+            - 'release/**'
     release:
         types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
         # Commits pushed to release/ branches are published on Test PyPI if they
         # have a new version number. This allows the maintainer to check the release
         # before it is pushed to the actual PyPI index.
-            - release/**
+            - 'release/**'
     release:
         types: [published]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,6 @@ name: Publish on Test PyPI and PyPI
 
 on:
     pull_request:
-        branches:
-        # Commits pushed to release/ branches are published on Test PyPI if they
-        # have a new version number. This allows the maintainer to check the release
-        # before it is pushed to the actual PyPI index.
-            - 'release/**'
     release:
         types: [published]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+            args: [--preserve-quotes]
 
     - repo: https://github.com/sirosen/check-jsonschema
       rev: 0.28.1


### PR DESCRIPTION
I noticed when releasing version 2.2.0 that the test publish workflow was not triggered on the PR in #593. This was my mistake: At some point I changed the triggering event from `push` to `pull_request`. However, the `branches` filter that we use so that the test-publish is only run on release branches, has a different semantic meaning for `pull_request` event --- it specifies the **target** branch, not the branch that is being merged. 