### PR TITLE
Speedup readthedocs build with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
                   python-version: '3.10'
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.27/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.44/uv-installer.sh | sh
 
             - name: Install package test dependencies
               # Notebook tests happen in the container, here we only need to install

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@
 
 version: 2
 
+# Using uv installer to speed up the build
+# https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
 build:
     os: ubuntu-22.04
     tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,8 @@ build:
         python: '3.11'
     commands:
         - asdf plugin add uv
-        - asdf install uv latest
-        - asdf global uv latest
+        - asdf install uv 0.1.44
+        - asdf global uv 0.1.44
         - uv venv
         - uv pip install .[docs]
-        - . .venv/bin/activate && .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html
+        - . .venv/bin/activate && .venv/bin/python -m sphinx -W --keep-going -d _build/doctrees -D language=en -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,4 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
-        - ls .venv/bin/
-        - . .venv/bin/activate
-        - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html
+        - . .venv/bin/activate && .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,14 +2,18 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the OS, Python version and other tools you might need
 build:
     os: ubuntu-22.04
     tools:
-        python: '3.10'
+        python: '3.11'
+    commands:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+        - uv venv
+        - uv pip install .[docs]
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -17,13 +21,3 @@ sphinx:
     builder: html
     # Let the build fail if there are any warnings
     fail_on_warning: true
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-              - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,6 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
+        - ls .venv/bin/
+        - . .venv/bin/activate
         - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,10 +14,4 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
-
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-    configuration: docs/source/conf.py
-    builder: html
-    # Let the build fail if there are any warnings
-    fail_on_warning: true
+        - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html


### PR DESCRIPTION
I configured the readthedocs build to use `uv` to install dependencies, according to https://github.com/readthedocs/readthedocs.org/pull/11322

This cuts the build time in half (by full minute!) so imo it's worth doing.