### PR TITLE
Hide private methods in API documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
                   python-version: '3.10'
 
             - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.27/uv-installer.sh | sh
+              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.1.44/uv-installer.sh | sh
 
             - name: Install package test dependencies
               # Notebook tests happen in the container, here we only need to install

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@
 
 version: 2
 
+# Using uv installer to speed up the build
+# https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
 build:
     os: ubuntu-22.04
     tools:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,4 @@ build:
         - asdf global uv 0.1.44
         - uv venv
         - uv pip install .[docs]
-        - . .venv/bin/activate && .venv/bin/python -m sphinx -W --keep-going -d _build/doctrees -D language=en -b html docs/source $READTHEDOCS_OUTPUT/html
+        - .venv/bin/python -m sphinx -W --keep-going -d _build/doctrees -D language=en -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,8 @@ build:
         python: '3.11'
     commands:
         - asdf plugin add uv
-        - asdf install uv latest
-        - asdf global uv latest
+        - asdf install uv 0.1.44
+        - asdf global uv 0.1.44
         - uv venv
         - uv pip install .[docs]
-        - . .venv/bin/activate && .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html
+        - . .venv/bin/activate && .venv/bin/python -m sphinx -W --keep-going -d _build/doctrees -D language=en -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,4 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
-        - ls .venv/bin/
-        - . .venv/bin/activate
-        - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html
+        - . .venv/bin/activate && .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,14 +2,18 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the OS, Python version and other tools you might need
 build:
     os: ubuntu-22.04
     tools:
-        python: '3.10'
+        python: '3.11'
+    commands:
+        - asdf plugin add uv
+        - asdf install uv latest
+        - asdf global uv latest
+        - uv venv
+        - uv pip install .[docs]
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -17,13 +21,3 @@ sphinx:
     builder: html
     # Let the build fail if there are any warnings
     fail_on_warning: true
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-    install:
-        - method: pip
-          path: .
-          extra_requirements:
-              - docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,6 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
+        - ls .venv/bin/
+        - . .venv/bin/activate
         - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,10 +14,4 @@ build:
         - asdf global uv latest
         - uv venv
         - uv pip install .[docs]
-
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-    configuration: docs/source/conf.py
-    builder: html
-    # Let the build fail if there are any warnings
-    fail_on_warning: true
+        - .venv/bin/python -m sphinx -W -b html docs/source $READTHEDOCS_OUTPUT/html

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,11 +2,14 @@
 
 # -*- coding: utf-8 -*-
 """Sphinx configuration for aiidalab-widgets-base."""
-import os
-import subprocess
-import sys
+
 import time
+import warnings
 from pathlib import Path
+
+warnings.filterwarnings(
+    "ignore", category=UserWarning, message="Creating AiiDA configuration folder .*"
+)
 
 from aiidalab_widgets_base import __version__  # pylint: disable=wrong-import-position
 
@@ -112,37 +115,23 @@ def run_apidoc(_):
     build on readthedocs.
     See also https://github.com/rtfd/readthedocs.org/issues/1139
     """
+    # https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-715284488
+    from sphinx.ext.apidoc import main
+
     source_dir = Path(__file__).resolve().parent
     apidoc_dir = source_dir / "apidoc"
     package_dir = source_dir.parent.parent / "aiidalab_widgets_base"
 
     symlink_example_notebooks(source_dir)
 
-    # In #1139, they suggest the route below, but this ended up
-    # calling sphinx-build, not sphinx-apidoc
-    # from sphinx.apidoc import main
-    # main([None, '-e', '-o', apidoc_dir, package_dir, '--force'])
-
-    cmd_path = "sphinx-apidoc"
-    if hasattr(sys, "real_prefix"):  # Check to see if we are in a virtualenv
-        # If we are, assemble the path manually
-        cmd_path = os.path.abspath(os.path.join(sys.prefix, "bin", "sphinx-apidoc"))
-
     options = [
-        "-o",
-        apidoc_dir,
-        package_dir,
-        "--private",
         "--force",
         "--no-toc",
+        "-o",
+        str(apidoc_dir),
+        str(package_dir),
     ]
-
-    # See https://stackoverflow.com/a/30144019
-    env = os.environ.copy()
-    env[
-        "SPHINX_APIDOC_OPTIONS"
-    ] = "members,special-members,private-members,undoc-members,show-inheritance"
-    subprocess.check_call([cmd_path, *options], env=env)
+    main(options)
 
 
 def setup(app):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,3 @@
-# pylint: disable=invalid-name
-
-# -*- coding: utf-8 -*-
 """Sphinx configuration for aiidalab-widgets-base."""
 
 import time
@@ -11,7 +8,7 @@ warnings.filterwarnings(
     "ignore", category=UserWarning, message="Creating AiiDA configuration folder .*"
 )
 
-from aiidalab_widgets_base import __version__  # pylint: disable=wrong-import-position
+from aiidalab_widgets_base import __version__
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -100,7 +97,7 @@ html_theme_options = {
 def symlink_example_notebooks(source_dir: Path):
     """Symlink example Jupyter notebooks.
 
-    Symlinks example jupyter notebooks so that they can be
+    Symlinks example Jupyter notebooks so that they can be
     included into the documentation.
     """
     notebooks_dir = source_dir.parent.parent / "notebooks"

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,10 +62,10 @@ smiles =
     rdkit>=2021.09.2
     scikit-learn~=1.0.0
 docs =
-    sphinx
-    sphinx-design
-    pydata-sphinx-theme
-    myst-nb
+    sphinx~=7.3
+    sphinx-design~=0.5
+    pydata-sphinx-theme~=0.15
+    myst-nb~=1.1
 
 [bumpver]
 current_version = "v2.2.2"


### PR DESCRIPTION
I noticed that the current [API documentation](https://aiidalab-widgets-base.readthedocs.io/en/latest/apidoc/aiidalab_widgets_base.html) is extremely messy, because it includes all the private methods. I am not sure what was the original motivation for this, but I'd suggest to remove it.

New version:
https://aiidalab-widgets-base--606.org.readthedocs.build/en/606/apidoc/aiidalab_widgets_base.html

Additional changes: 
 - simplified the sphinx-apidoc invocation
 - basic pins for docs dependencies to make the build more future-proof