### PR TITLE
Make ELN widgets optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
             # Ideally, these would be fixed, but vapory is largely unmaintained,
             # so here we simply keep the pip behaviour with the --compile flag.
             # See https://github.com/astral-sh/uv/issues/1928#issuecomment-1968857514
-              run: uv pip install --compile --system .[dev,smiles,optimade] aiida-core==${{ matrix.aiida-core-version }}
+              run: uv pip install --compile --system .[dev,smiles,optimade,eln] aiida-core==${{ matrix.aiida-core-version }}
 
             - name: Run pytest
               run: pytest -v tests --cov

--- a/aiidalab_widgets_base/elns.py
+++ b/aiidalab_widgets_base/elns.py
@@ -5,7 +5,6 @@ import ipywidgets as ipw
 import requests_cache
 import traitlets as tl
 from aiida import orm
-from aiidalab_eln import get_eln_connector
 from IPython.display import clear_output, display
 
 ELN_CONFIG = Path.home() / ".aiidalab" / "aiidalab-eln-config.json"
@@ -15,6 +14,13 @@ ELN_CONFIG.parent.mkdir(
 
 
 def connect_to_eln(eln_instance=None, **kwargs):
+    try:
+        from aiidalab_eln import get_eln_connector
+    except ImportError:
+        return (
+            None,
+            "AiiDAlab-ELN connector not installed. Install with `pip install aiidalab-eln`",
+        )
     # assuming that the connection can only be established to the ELNs
     # with the stored configuration.
     try:
@@ -276,6 +282,15 @@ class ElnConfigureWidget(ipw.VBox):
 
     def display_eln_config(self, value=None):
         """Display ELN configuration specific to the selected type of ELN."""
+        try:
+            from aiidalab_eln import get_eln_connector
+        except ImportError:
+            with self._output:
+                clear_output()
+                msg = "AiiDAlab-ELN connector not installed. Install with `pip install aiidalab-eln`"
+                display(ipw.HTML(f"&#10060; {msg}"))
+            return
+
         try:
             eln_class = get_eln_connector(self.eln_types.value)
         except NotImplementedError as err:

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     PyCifRW~=4.4
     aiida-core>=2.1,<3
     aiidalab>=21.11.2
-    aiidalab-eln>=0.1.2,~=0.1
     ansi2html~=1.6
     ase~=3.18
     bokeh~=2.0
@@ -54,6 +53,8 @@ dev =
     selenium==4.20.0
 optimade =
     ipyoptimade~=0.1
+eln =
+    aiidalab-eln>=0.1.2,~=0.1
 smiles =
     rdkit>=2021.09.2
     scikit-learn~=1.0.0


### PR DESCRIPTION
As discussed in #608 and #595, this PR makes `aiidalab-eln` dependency optional via new `eln` extras. The ELN widgets will show an error if the dependency is not installed. 

@edan-bainglass @yakutovicha please test, I am not familiar with these widgets. Also please feel free to tweak the error message.

WARNING: This is a breaking change and so it should be released in 0.2.3.