### PR TITLE
deps: Vendor more_itertools.consecutive_groups

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     traitlets~=5.9.0
     ipywidgets~=7.7
     widgetsnbextension<3.6.3
-    more-itertools~=8.0
     pymysql~=0.9
     nglview~=3.0
     spglib>=1.14,<3


### PR DESCRIPTION
`more_itertools` package contains useful functions built on top of stdlib itertools, but we only use a single function from the package so let's vendor it and remove the dependency. 

This means app developers can happily use this package without worrying about version clashes with AWB. 

Part of #392 