### PR TITLE
Test with aiida 2.6.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
     FORCE_COLOR: "1"
-    UV_VERSION: "0.2.17"
+    UV_VERSION: "0.4.6"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -27,7 +27,7 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                aiida-core-version: [2.1.2, 2.5.1]
+                aiida-core-version: [2.1.2, 2.6.2]
             fail-fast: false
 
         runs-on: ubuntu-latest
@@ -43,8 +43,10 @@ jobs:
               with:
                   python-version: '3.10'
 
-            - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh | sh
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v1
+              with:
+                  version: ${{ env.UV_VERSION }}
 
             - name: Install package test dependencies
               # Notebook tests happen in the container, here we only need to install
@@ -88,7 +90,7 @@ jobs:
             matrix:
                 python-version: ['3.9', '3.11']
                 # Test on the latest and oldest supported version
-                aiida-core-version: [2.2.2, 2.5.1]
+                aiida-core-version: [2.2.2, 2.6.2]
             fail-fast: false
 
         runs-on: ubuntu-latest
@@ -111,8 +113,10 @@ jobs:
               with:
                   python-version: ${{ matrix.python-version }}
 
-            - name: Install uv
-              run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh | sh
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v1
+              with:
+                  version: ${{ env.UV_VERSION }}
 
             - name: Install package
             # NOTE: uv (unlike pip) does not compile python to bytecode after install.


### PR DESCRIPTION
Just released a new image with aiida-2.6.2 so we should switch our tests (both notebook tests and unit tests) here to this version.