### PR TITLE
Adding support for `orm.Containerized` codes

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1204,7 +1204,7 @@ class AiidaCodeSetup(ipw.VBox):
             kwargs = {key: getattr(self, key).value for key in items_to_configure}
 
             # Check for additional keys needed for orm.ContainerizedCode
-            for container_key in containerized_codes_additional_items:
+            for container_key in containerized_code_additional_items:
                 if container_key in self.code_setup.keys():
                     kwargs[container_key] = self.code_setup[container_key]
 

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1215,7 +1215,7 @@ class AiidaCodeSetup(ipw.VBox):
             qb = orm.QueryBuilder()
             qb.append(orm.Computer, filters={"uuid": computer.uuid}, tag="computer")
             qb.append(
-                (orm.InstalledCode, orm.ContainerizedCode),
+                orm.AbstractCode,
                 with_computer="computer",
                 filters={"label": kwargs["label"]},
             )

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1196,7 +1196,7 @@ class AiidaCodeSetup(ipw.VBox):
                 "append_text",
             ]
 
-            containerized_codes_additional_items = [
+            containerized_code_additional_items = [
                 "image_name",
                 "engine_command",
             ]


### PR DESCRIPTION
This is obtained using the AiidaCodeSetup().code_setup attribute. 

I am not sure is the better way, as we should also provide the possibility to change the `image_name` and the `engine_command` via the GUI. However, I think that for now this is acceptable, as the containerized codes are mainly 
set up by using the information on the `aiida-resource-registry` repo. Actually, it is a really new thing and for now only the `phonopy@merlin-cpu` is defined. 
