### PR TITLE
Make auto-generated release notes nicer

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+---
+# Configuration for automatically generated release notes:
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes
+# We exclude PRs from bots and categorize PRs based on labels
+changelog:
+    exclude:
+        authors:
+            - dependabot
+            - pre-commit-ci
+    categories:
+        - title: Breaking Changes 🛠
+          labels:
+              - breaking
+        - title: New Features 🎉
+          labels:
+              - enhancement
+        - title: Bug fixes 🐛
+          labels:
+              - bug
+        - title: Documentation 📝
+          labels:
+              - docs
+        - title: Other Changes
+          labels:
+              - "*"


### PR DESCRIPTION
Adds a configuration for [auto-generated release notes](url) to make them a bit nicer:

1. Exclude PRs from dependabot and pre-commit-ci bot
2. Autogenerate sections based on labels on the PRs. (this requires a bit of extra work to label the PRs, let's see if we like it or not).