### PR TITLE
Support and test with py3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.10']
+                python-version: ['3.9', '3.11']
                 # Test on the latest and oldest supported version
                 aiida-core-version: [2.2.2, 2.5.1]
             fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,16 @@ build-backend = "setuptools.build_meta"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    # The following deprecation warnings come from Python 3.12 stdlib modules
+    "ignore:datetime.datetime.:DeprecationWarning:",
+    # This one is coming from plumpy
+    "ignore:There is no current event loop:DeprecationWarning:",
+    # This deprecation warning coming from sqlite3 module might go away if we update bokeh
+    "ignore:The default datetime adapter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes:DeprecationWarning:",
     # This is needed since SQLAlchemy 2.0, see
     # https://github.com/aiidalab/aiidalab-widgets-base/issues/605
     'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
-    'ignore::DeprecationWarning:bokeh.core.property.primitive',
+    'ignore::DeprecationWarning:bokeh',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:The `Code` class:aiida.common.warnings.AiidaDeprecationWarning:',
     'ignore:crystal system:UserWarning:ase.io.cif',
@@ -25,6 +31,9 @@ filterwarnings = [
     # https://github.com/aiidalab/aiidalab-widgets-base/issues/551
     'ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning:_pytest',
     'ignore::DeprecationWarning:jupyter_client',
+    # This warning is coming from circus (aiida-core dependency):
+    # https://github.com/circus-tent/circus/issues/1215
+    "ignore:'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning:",
 ]
 
 [tool.ruff]

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ eln =
     aiidalab-eln>=0.1.2,~=0.1
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=1.0.0
+    scikit-learn~=1.1
 docs =
     sphinx~=7.3
     sphinx-design~=0.5


### PR DESCRIPTION
To support Python 3.11, we need to bump the scikit-learn dependency, and ignore some more DeprecationWarnings. Otherwise things seem to work. 