### PR TITLE
Bump version v2.2.2 -> v2.3.0a0

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -117,4 +117,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "2.2.2"
+__version__ = "2.3.0a0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ docs =
     myst-nb~=1.1
 
 [bumpver]
-current_version = "v2.2.2"
+current_version = "v2.3.0a0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
Releasing an alpha version so that I can start preparing a conda package.