### PR TITLE
Bump version v2.3.0a0 -> v2.3.0a1

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -117,4 +117,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "2.3.0a0"
+__version__ = "2.3.0a1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ docs =
     myst-nb~=1.1
 
 [bumpver]
-current_version = "v2.3.0a0"
+current_version = "v2.3.0a1"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
New release which fixes some dependency issue blocking the conda build. 