### PR TITLE
Fix warnings in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    'error',
     # The following deprecation warnings come from Python 3.12 stdlib modules
     "ignore:datetime.datetime.:DeprecationWarning:",
     # This one is coming from plumpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ filterwarnings = [
     # This warning is coming from circus (aiida-core dependency):
     # https://github.com/circus-tent/circus/issues/1215
     "ignore:'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning:",
+    "ignore::cryptography.utils.CryptographyDeprecationWarning:",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,15 @@ filterwarnings = [
     "ignore:The default datetime adapter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes:DeprecationWarning:",
     # This is needed since SQLAlchemy 2.0, see
     # https://github.com/aiidalab/aiidalab-widgets-base/issues/605
-    'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
+    'ignore:Object of type.*not in session,.*operation along.*will not proceed:sqlalchemy.exc.SAWarning',
     'ignore::DeprecationWarning:bokeh',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:The `Code` class:aiida.common.warnings.AiidaDeprecationWarning:',
     'ignore:crystal system:UserWarning:ase.io.cif',
     'ignore::DeprecationWarning:ase.atoms',
+    # This popped up in spglib 2.5. Since we still try to support spglib v1,
+    # it's not clear if we can get rid of it.
+    "ignore:dict interface.*is deprecated.Use attribute interface:DeprecationWarning:spglib",
     # TODO: This comes from a transitive dependency of ipyoptimade
     # Remove this when this issue is addressed:
     # https://github.com/CasperWA/ipywidgets-extended/issues/85


### PR DESCRIPTION
Added some ignores for deprecation warnings.

I have decided to remove the settings that turned warnings into hard errors, since it turned out to be too much of a hassle. 