### PR TITLE
Downgrade minimum traitlets version to 5.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     bokeh~=2.0
     humanfriendly~=10.0
     ipytree~=0.2
-    traitlets~=5.9
+    traitlets~=5.4
     ipywidgets~=7.7
     widgetsnbextension<3.6.3
     pymysql~=0.9


### PR DESCRIPTION
In #621 I've unpinned traitlets dependency from `traitlets==5.9.0` to `traitlets~=5.9`. What I did not realize, and we found out the hard way in aiidalab/aiidalab-docker-stack#494, `traitlets>=5.10` break the jupyter notebook version in the current AiiDAlab image.

As aiidalab/aiidalab-docker-stack#494 showed as, it is really not good if traitlets dependency is installed outside of the conda enviroment (i.e. to ~/.local) as it may break the jupyter notebook. Here we downgrade the minimum traitlets version back to 5.4.

(NOTE: That the original motivation to upgrading to 5.9 was performance, I believe it is better if we upgrade directly in the image). I'll open a separate issue for discussion, this is just a hotfix. 

Fixes aiidalab/aiidalab-docker-stack#494