### PR TITLE
Fix notebook tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,12 +44,12 @@ dev =
     bumpver>=2023.1129
     pgtest~=1.3
     pre-commit>=3.5
-    pytest~=8.2.0
+    pytest~=8.3.0
     pytest-cov~=5.0
-    pytest-docker~=3.0
-    pytest-selenium~=4.1
-    pytest-timeout~=2.2
-    selenium==4.20.0
+    pytest-docker~=3.1.0
+    pytest-selenium~=4.1.0
+    pytest-timeout~=2.3.0
+    selenium~=4.23.0
 optimade =
     ipyoptimade~=0.1
 eln =

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -1,5 +1,4 @@
 import os
-import time
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -114,7 +113,7 @@ def selenium_driver(selenium, notebook_service):
         # We wait until the appmode spinner disappears. However,
         # this does not seem to be fully robust, as the spinner might flash
         # while the page is still loading. So we add explicit sleep here as well.
-        time.sleep(10)
+        # time.sleep(10)
         WebDriverWait(selenium, 240).until(
             ec.invisibility_of_element((By.ID, "appmode-busy"))
         )

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -99,16 +100,21 @@ def selenium_driver(selenium, notebook_service):
             url, f"apps/apps/aiidalab-widgets-base/{nb_path}?token={token}"
         )
         selenium.get(f"{url_with_token}")
-        # By default, let's allow selenium functions to retry for 10s
+        # By default, let's allow selenium functions to retry for 60s
         # till a given element is loaded, see:
         # https://selenium-python.readthedocs.io/waits.html#implicit-waits
-        selenium.implicitly_wait(30)
+        selenium.implicitly_wait(60)
         window_width = 800
         window_height = 600
         selenium.set_window_size(window_width, window_height)
 
         selenium.find_element(By.ID, "ipython-main-app")
         selenium.find_element(By.ID, "notebook-container")
+        selenium.find_element(By.ID, "appmode-busy")
+        # We wait until the appmode spinner disappears. However,
+        # this does not seem to be fully robust, as the spinner might flash
+        # while the page is still loading. So we add explicit sleep here as well.
+        time.sleep(10)
         WebDriverWait(selenium, 240).until(
             ec.invisibility_of_element((By.ID, "appmode-busy"))
         )

--- a/tests_notebooks/conftest.py
+++ b/tests_notebooks/conftest.py
@@ -113,7 +113,6 @@ def selenium_driver(selenium, notebook_service):
         # We wait until the appmode spinner disappears. However,
         # this does not seem to be fully robust, as the spinner might flash
         # while the page is still loading. So we add explicit sleep here as well.
-        # time.sleep(10)
         WebDriverWait(selenium, 240).until(
             ec.invisibility_of_element((By.ID, "appmode-busy"))
         )


### PR DESCRIPTION
The last successfully run of notebook tests is from July 8. There were no code changes that should impact the tests, we need to investigate what changed since then.

EDIT: It looks like just increasing the wait time tolerance fixes the issue. Perhaps the github runners just got slower? Not sure.