### PR TITLE
Allow user to hide the header of the Wizard App

### DIFF
--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -88,7 +88,7 @@ class WizardAppWidget(ipw.VBox):
 
     selected_index = tl.Int(allow_none=True)
 
-    def __init__(self, steps, hide_header=False, **kwargs):
+    def __init__(self, steps, show_header=True, **kwargs):
         # The number of steps must be greater than one
         # for this app's logic to make sense.
         if len(steps) < 2:
@@ -145,10 +145,17 @@ class WizardAppWidget(ipw.VBox):
         self.header = ipw.HBox(
             children=[self.back_button, self.reset_button, self.next_button]
         )
+        self.show_header = show_header
 
-        if hide_header:
-            self.header.layout.display = "none"
         super().__init__(children=[self.header, self.accordion], **kwargs)
+
+    @property
+    def show_header(self):
+        return self.header.layout.display != "none"
+
+    @show_header.setter
+    def show_header(self, value):
+        self.header.layout.display = "flex" if value else "none"
 
     def _update_titles(self):
         for i, (title, widget) in enumerate(zip(self.titles, self.accordion.children)):

--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -88,7 +88,7 @@ class WizardAppWidget(ipw.VBox):
 
     selected_index = tl.Int(allow_none=True)
 
-    def __init__(self, steps, **kwargs):
+    def __init__(self, steps, hide_header=False, **kwargs):
         # The number of steps must be greater than one
         # for this app's logic to make sense.
         if len(steps) < 2:
@@ -142,11 +142,13 @@ class WizardAppWidget(ipw.VBox):
         )
         self.next_button.on_click(self._on_click_next_button)
 
-        header = ipw.HBox(
+        self.header = ipw.HBox(
             children=[self.back_button, self.reset_button, self.next_button]
         )
 
-        super().__init__(children=[header, self.accordion], **kwargs)
+        if hide_header:
+            self.header.layout.display = "none"
+        super().__init__(children=[self.header, self.accordion], **kwargs)
 
     def _update_titles(self):
         for i, (title, widget) in enumerate(zip(self.titles, self.accordion.children)):


### PR DESCRIPTION
We plan to remove the header in the QE App, as suggested by @giovannipizzi and @cpignedoli in https://github.com/aiidalab/aiidalab-qe/issues/813.

This PR allows the user to hide the header of the Wizard App.