### PR TITLE
Backport to 2.2.x: Support and test with py3.11 (#619)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.10']
+                python-version: ['3.9', '3.11']
                 # Test on the latest and oldest supported version
                 aiida-core-version: [2.2.2, 2.4.3]
             fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     push:
         branches:
             - main
+            - support/*
     pull_request:
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
             - support/*
     pull_request:
 
+env:
+    FORCE_COLOR: "1"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -24,10 +26,11 @@ jobs:
         strategy:
             matrix:
                 browser: [Chrome, Firefox]
-                aiida-core-version: [2.1.2, 2.4.3]          # test on the latest and the oldest supported version
+                # test on the latest and the oldest supported version
+                aiida-core-version: [2.1.2, 2.6.3]
             fail-fast: false
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         steps:
@@ -85,10 +88,10 @@ jobs:
             matrix:
                 python-version: ['3.9', '3.11']
                 # Test on the latest and oldest supported version
-                aiida-core-version: [2.2.2, 2.4.3]
+                aiida-core-version: [2.2.2, 2.6.3]
             fail-fast: false
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         timeout-minutes: 30
         services:
             rabbitmq:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     build:
 
         name: Build package
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         steps:
 
@@ -52,7 +52,7 @@ jobs:
         if: github.repository_owner == 'aiidalab'
 
         needs: [build]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         environment:
             name: Test PyPI
@@ -79,7 +79,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'aiidalab'
 
         needs: [build, publish-test]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         environment:
             name: PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,16 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 filterwarnings = [
-    'error',
-    'ignore::DeprecationWarning:bokeh.core.property.primitive',
+    # The following deprecation warnings come from Python 3.12 stdlib modules
+    "ignore:datetime.datetime.:DeprecationWarning:",
+    # This one is coming from plumpy
+    "ignore:There is no current event loop:DeprecationWarning:",
+    # This deprecation warning coming from sqlite3 module might go away if we update bokeh
+    "ignore:The default datetime adapter is deprecated as of Python 3.12; see the sqlite3 documentation for suggested replacement recipes:DeprecationWarning:",
+    # This is needed since SQLAlchemy 2.0, see
+    # https://github.com/aiidalab/aiidalab-widgets-base/issues/605
+    'ignore:Object of type .* not in session, .* operation along .* will not proceed:sqlalchemy.exc.SAWarning',
+    'ignore::DeprecationWarning:bokeh',
     'ignore:Creating AiiDA configuration:UserWarning:aiida',
     'ignore:crystal system:UserWarning:ase.io.cif',
     'ignore::DeprecationWarning:ase.atoms',
@@ -22,8 +30,9 @@ filterwarnings = [
     'ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning:_pytest',
     'ignore::DeprecationWarning:pytest_html',
     'ignore::DeprecationWarning:jupyter_client',
-    'ignore::DeprecationWarning:selenium',
-    'ignore::DeprecationWarning:pytest_selenium',
+    # This warning is coming from circus (aiida-core dependency):
+    # https://github.com/circus-tent/circus/issues/1215
+    "ignore:'pipes' is deprecated and slated for removal in Python 3.13:DeprecationWarning:",
 ]
 
 [tool.ruff]

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ optimade =
     ipyoptimade~=0.1
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=1.0.0
+    scikit-learn~=1.1
 docs =
     sphinx
     sphinx-design

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -71,7 +71,7 @@ def test_folder_data_viewer(folder_data_object):
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
-def test_structure_data_viewer_storage(structure_data_object):
+def test_structure_data_viewer_storage(monkeypatch, tmp_path, structure_data_object):
     v = viewers.viewer(structure_data_object)
     assert isinstance(v, viewers.StructureDataViewer)
 
@@ -87,13 +87,13 @@ def test_structure_data_viewer_storage(structure_data_object):
         ),
         (
             "cif",
-            """ZGF0YV9pbWFnZTAKX2NoZW1pY2FsX2Zvcm11bGFfc3RydWN0dXJhbCAgICAgICBTaTIKX2NoZW1pY2FsX2Zvcm11bGFfc3VtICAgICAgICAgICAgICAiU2kyIgpfY2VsbF9sZW5ndGhfYSAgICAgICAzLjg0NzM3Cl9jZWxsX2xlbmd0aF9iICAgICAgIDMuODQ3MzcKX2NlbGxfbGVuZ3RoX2MgICAgICAgMy44NDczNwpfY2VsbF9hbmdsZV9hbHBoYSAgICA2MApfY2VsbF9hbmdsZV9iZXRhICAgICA2MApfY2VsbF9hbmdsZV9nYW1tYSAgICA2MAoKX3NwYWNlX2dyb3VwX25hbWVfSC1NX2FsdCAgICAiUCAxIgpfc3BhY2VfZ3JvdXBfSVRfbnVtYmVyICAgICAgIDEKCmxvb3BfCiAgX3NwYWNlX2dyb3VwX3N5bW9wX29wZXJhdGlvbl94eXoKICAneCwgeSwgeicKCmxvb3BfCiAgX2F0b21fc2l0ZV90eXBlX3N5bWJvbAogIF9hdG9tX3NpdGVfbGFiZWwKICBfYXRvbV9zaXRlX3N5bW1ldHJ5X211bHRpcGxpY2l0eQogIF9hdG9tX3NpdGVfZnJhY3RfeAogIF9hdG9tX3NpdGVfZnJhY3RfeQogIF9hdG9tX3NpdGVfZnJhY3RfegogIF9hdG9tX3NpdGVfb2NjdXBhbmN5CiAgU2kgIFNpMSAgICAgICAxLjAgIDAuMDAwMDAgIDAuMDAwMDAgIDAuMDAwMDAgIDEuMDAwMAogIFNpICBTaTIgICAgICAgMS4wICAwLjI1MDAwICAwLjI1MDAwICAwLjI1MDAwICAxLjAwMDAK""",
+            """ZGF0YV9pbWFnZTAKX2NoZW1pY2FsX2Zvcm11bGFfc3RydWN0dXJhbCAgICAgICBTaTIKX2NoZW1pY2FsX2Zvcm11bGFfc3VtICAgICAgICAgICAgICAiU2kyIgpfY2VsbF9sZW5ndGhfYSAgICAgICAzLjg0NzM3Cl9jZWxsX2xlbmd0aF9iICAgICAgIDMuODQ3MzY5ODYzMzc3NDQ4Cl9jZWxsX2xlbmd0aF9jICAgICAgIDMuODQ3MzY5NjE2OTM1ODM2Cl9jZWxsX2FuZ2xlX2FscGhhICAgIDU5Ljk5OTk5NzA5Nzk3MDEyCl9jZWxsX2FuZ2xlX2JldGEgICAgIDU5Ljk5OTk5NjcwNjQwOTMwNgpfY2VsbF9hbmdsZV9nYW1tYSAgICA1OS45OTk5OTg4MjUzMTc1OQoKX3NwYWNlX2dyb3VwX25hbWVfSC1NX2FsdCAgICAiUCAxIgpfc3BhY2VfZ3JvdXBfSVRfbnVtYmVyICAgICAgIDEKCmxvb3BfCiAgX3NwYWNlX2dyb3VwX3N5bW9wX29wZXJhdGlvbl94eXoKICAneCwgeSwgeicKCmxvb3BfCiAgX2F0b21fc2l0ZV90eXBlX3N5bWJvbAogIF9hdG9tX3NpdGVfbGFiZWwKICBfYXRvbV9zaXRlX3N5bW1ldHJ5X211bHRpcGxpY2l0eQogIF9hdG9tX3NpdGVfZnJhY3RfeAogIF9hdG9tX3NpdGVfZnJhY3RfeQogIF9hdG9tX3NpdGVfZnJhY3RfegogIF9hdG9tX3NpdGVfb2NjdXBhbmN5CiAgU2kgIFNpMSAgICAgICAxLjAgIDAuMCAgMC4wICAwLjAgIDEuMDAwMAogIFNpICBTaTIgICAgICAgMS4wICAwLjI1MDAwMDAwMDAwMDAwMDA2ICAwLjI1ICAwLjI1ICAxLjAwMDAK""",
         ),
     ]
 
     for fmt, out in format_cases:
         v.file_format.label = fmt
-        assert v._prepare_payload() == out
+        assert v._prepare_payload() == out, f"{fmt} structure payload does not match"
 
     # Monkey patch the viewer to avoid the need for a running X server.
     # fmt: off
@@ -104,6 +104,8 @@ def test_structure_data_viewer_storage(structure_data_object):
         -1.6859999895095825, -1.6859999895095825, -0.6669999957084656, 1,
     ]
     # fmt: on
+    # Avoid producing temporary files from povray in the repo
+    monkeypatch.chdir(tmp_path)
     v._render_structure()
 
 


### PR DESCRIPTION
Update scikit-learn dependency to support python 3.11

We're backporting this to 2.2.x release line so that it is available in the new (soon to be published) docker container based on Python 3.11