### PR TITLE
Silence warning

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1302,6 +1302,13 @@ class AiidaCodeSetup(ipw.VBox):
         for key, value in self.code_setup.items():
             if hasattr(self, key):
                 if key == "default_calc_job_plugin":
+                    if "None" in value:
+                        # NOTE: Using this widget through the `_ResourceSetupBaseWidget`
+                        # without an explicit `default_calc_job_plugin` causes `value`
+                        # to be "<plugin>.None", which is not a valid plugin name.
+                        # HACK to avoid the warning message
+                        # TODO see https://github.com/aiidalab/aiidalab-widgets-base/issues/648
+                        return
                     try:
                         self.default_calc_job_plugin.value = value
                     except tl.TraitError:


### PR DESCRIPTION
Recent developments in aiidalab-home of an external notebook to manage codes run into an issue with the AWB computational resources widgets when used without a default calcjob plugin. This PR silences a suspected false warning for now, to be properly investigated in a future PR.

Handling issue #648