### PR TITLE
Replace check of empty string in unfilled template widgets to `None`

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1302,13 +1302,6 @@ class AiidaCodeSetup(ipw.VBox):
         for key, value in self.code_setup.items():
             if hasattr(self, key):
                 if key == "default_calc_job_plugin":
-                    if "None" in value:
-                        # NOTE: Using this widget through the `_ResourceSetupBaseWidget`
-                        # without an explicit `default_calc_job_plugin` causes `value`
-                        # to be "<plugin>.None", which is not a valid plugin name.
-                        # HACK to avoid the warning message
-                        # TODO see https://github.com/aiidalab/aiidalab-widgets-base/issues/648
-                        return
                     try:
                         self.default_calc_job_plugin.value = value
                     except tl.TraitError:
@@ -1597,7 +1590,7 @@ class TemplateVariablesWidget(ipw.VBox):
                 # if the widget is not filled, use the original template var string e.g. {{ var }}
                 inp_dict = {}
                 for _var in line.vars:
-                    if self._template_variables[_var].widget.value == "":
+                    if self._template_variables[_var].widget.value in ("", None):
                         variable_key = self._template_variables[_var].widget.description
                         self.unfilled_variables.append(variable_key.strip(":"))
                         inp_dict[_var] = "{{ " + _var + " }}"


### PR DESCRIPTION
This PR corrects a guard for unfilled template variables which checks if the value of the corresponding widget is an empty string. Empty widgets may also be represented by `None`, especially dropdown selectors. This PR adds `None` to the check by comparing the widget's value to both - replaces `== ""` with `in ("", None)`.

Resolves #648
Resolves #651

@superstar54 @danielhollas have a look 🙏
@unkcpz tagging you due to git blame (suggests you implemented these sections)