### PR TITLE
Add volume information in the cell tab

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -16,6 +16,7 @@ import spglib
 import traitlets as tl
 import vapory
 from aiida import cmdline, orm, tools
+from aiida.orm.nodes.data.structure import _get_dimensionality
 from ase.data import colors
 from IPython.display import clear_output, display
 from matplotlib.colors import to_rgb
@@ -710,6 +711,21 @@ class _StructureDataBaseViewer(ipw.VBox):
             self.periodicity.value = (
                 f"Periodicity: {periodicity_map[tuple(self.structure.pbc)]}"
             )
+            # Calculate the volume of the cell using the function from orm.StructureData
+            dimension_data = _get_dimensionality(self.structure.pbc, self.cell)
+            # Determine the label and unit based on dimensionality
+            cell_labels = {
+                1: ["length", "Å"],
+                2: ["area", "Å²"],
+                3: ["volume", "Å³"],
+            }
+            cell_label = cell_labels.get(dimension_data["dim"])
+            if cell_label:
+                self.cell_volume.value = f"Cell {cell_label[0]}: {dimension_data['value']:.4f} ({cell_label[1]})"
+            else:
+                self.cell_volume.value = f"Cell volume: -"
+            
+
         else:
             self.cell_a.value = "<i><b>a</b></i>:"
             self.cell_b.value = "<i><b>b</b></i>:"
@@ -743,6 +759,8 @@ class _StructureDataBaseViewer(ipw.VBox):
         self.cell_spacegroup = ipw.HTML()
         self.cell_hall = ipw.HTML()
         self.periodicity = ipw.HTML()
+
+        self.cell_volume = ipw.HTML()
 
         self._observe_cell()
 
@@ -791,6 +809,7 @@ class _StructureDataBaseViewer(ipw.VBox):
                         ),
                     ]
                 ),
+                self.cell_volume,
             ]
         )
 

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -283,6 +283,11 @@ class _StructureDataBaseViewer(ipw.VBox):
     DEFAULT_SELECTION_COLOR = "green"
     REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
     DEFAULT_REPRESENTATION = "_aiidalab_viewer_representation_default"
+    _CELL_LABELS = {
+        1: ["length", "Å"],
+        2: ["area", "Å²"],
+        3: ["volume", "Å³"],
+    }
 
     def __init__(
         self,
@@ -714,12 +719,7 @@ class _StructureDataBaseViewer(ipw.VBox):
             # Calculate the volume of the cell using the function from orm.StructureData
             dimension_data = _get_dimensionality(self.structure.pbc, self.cell)
             # Determine the label and unit based on dimensionality
-            cell_labels = {
-                1: ["length", "Å"],
-                2: ["area", "Å²"],
-                3: ["volume", "Å³"],
-            }
-            cell_label = cell_labels.get(dimension_data["dim"])
+            cell_label = self._CELL_LABELS.get(dimension_data["dim"])
             if cell_label:
                 self.cell_volume.value = f"Cell {cell_label[0]}: {dimension_data['value']:.4f} ({cell_label[1]})"
             else:

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -723,8 +723,7 @@ class _StructureDataBaseViewer(ipw.VBox):
             if cell_label:
                 self.cell_volume.value = f"Cell {cell_label[0]}: {dimension_data['value']:.4f} ({cell_label[1]})"
             else:
-                self.cell_volume.value = f"Cell volume: -"
-            
+                self.cell_volume.value = "Cell volume: -"
 
         else:
             self.cell_a.value = "<i><b>a</b></i>:"

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -19,6 +19,7 @@ def test_pbc_structure_data_viewer(structure_data_object):
     viewer = viewers.StructureDataViewer()
     viewer.structure = ase_input
     assert viewer.periodicity.value == "Periodicity: xy"
+    assert viewer.cell_volume.value == "Cell area: 12.2500 (Å²)"
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")


### PR DESCRIPTION
Fix #652 . 

Add volume information in the cell tab, the text depends on the periodic boundary condtion.
- xyz -> Cell volume (ang^3)
- xy -> Cell area (ang^2)
- x -> Cell length (and)

As suggested by @cpignedoli , we use the [function](https://github.com/aiidateam/aiida-core/blob/779cc29d8a47eddabdf9b274d7fa711220ee1aa9/src/aiida/orm/nodes/data/structure.py#L2412) from `orm.StructureData` directly. Note, the cell tab is inside class `_StructureDataBaseViewer`, which uses `ase.Atoms` to store the structure, so we can not use `StructureData.get_dimensionality` directly, but use the private function `_get_dimensionality`. Even though it's a private function, I decided to use it so we get updated in the future automatically and do not re-write duplicate code.
