### PR TITLE
Clarify structure operations

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -113,29 +113,58 @@ class StructureManagerWidget(ipw.VBox):
             raise ValueError(
                 f"Unknown data format '{node_class}'. Options: {list(self.SUPPORTED_DATA_FORMATS.keys())}"
             )
-        self.output = ipw.HTML("")
 
-        children = [
-            self._structure_importers(importers),
-            self.viewer,
-            ipw.HBox(
-                [
-                    *store_and_description,
-                    self.structure_label,
-                    self.structure_description,
-                ]
-            ),
-        ]
+        viewer_panel = ipw.Accordion(
+            children=[
+                ipw.VBox(
+                    children=[
+                        self.viewer,
+                        ipw.HBox(
+                            children=[
+                                *store_and_description,
+                                self.structure_label,
+                                self.structure_description,
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            selected_index=0,
+        )
+        viewer_panel.set_title(0, "View structure")
 
         structure_editors = self._structure_editors(editors)
         if structure_editors:
-            structure_editors = ipw.VBox([btn_undo, structure_editors])
-            accordion = ipw.Accordion([structure_editors])
-            accordion.selected_index = None
-            accordion.set_title(0, "Edit structure")
-            children += [accordion]
+            structure_editors = ipw.VBox(
+                children=[
+                    btn_undo,
+                    structure_editors,
+                ]
+            )
 
-        super().__init__(children=[*children, self.output], **kwargs)
+        editor_panel = ipw.Accordion(
+            children=[
+                ipw.VBox(
+                    children=[
+                        structure_editors,
+                    ]
+                ),
+            ],
+            selected_index=None,
+        )
+        editor_panel.set_title(0, "Edit structure")
+
+        self.output = ipw.HTML("")
+
+        super().__init__(
+            children=[
+                self._structure_importers(importers),
+                viewer_panel,
+                editor_panel,
+                self.output,
+            ],
+            **kwargs,
+        )
 
         self.add_class("structure-manager")
 

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -424,7 +424,7 @@ class _StructureDataBaseViewer(ipw.VBox):
         supercell_selector = ipw.HBox(
             [
                 ipw.HTML(
-                    description="Super cell:", style={"description_width": "initial"}
+                    description="Supercell:", style={"description_width": "initial"}
                 ),
                 *_supercell,
             ]
@@ -524,8 +524,8 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         info = ipw.HTML("""
             <div style="line-height: 1.5; max-width: 460px; margin: 6px 2px;">
-                <b>Note:</b> The super cell settings here are <b>for visualization
-                purposes only</b>. To simulate a super cell, open the <b>Edit
+                <b>Note:</b> The supercell settings here are <b>for visualization
+                purposes only</b>. To simulate a supercell, open the <b>Edit
                 structure</b> panel below, navigate to the <b>Edit cell</b> tab, and
                 use the <b>Cell transformation</b> controls.
             </div>
@@ -1045,7 +1045,7 @@ class _StructureDataBaseViewer(ipw.VBox):
         # Exclude everything that is beyond the total number of atoms.
         selection_list = [x for x in value["new"] if x < self.natoms]
 
-        # In the case of a super cell, we need to multiply the selection as well
+        # In the case of a supercell, we need to multiply the selection as well
         multiplier = sum(self.supercell) - 2
         selection_list = [
             x + self.natoms * i for x in selection_list for i in range(multiplier)
@@ -1144,7 +1144,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
         ASE Atoms object or to AiiDA structure object containing `get_ase()` method.
 
         displayed_structure (Atoms): Trait that contains a structure object that is
-        currently displayed (super cell, for example). The trait is generated automatically
+        currently displayed (supercell, for example). The trait is generated automatically
         and can't be set outside of the class.
     """
 

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -522,9 +522,19 @@ class _StructureDataBaseViewer(ipw.VBox):
         representation_accordion.set_title(0, "Representations")
         representation_accordion.selected_index = None
 
+        info = ipw.HTML("""
+            <div style="line-height: 1.5; max-width: 460px; margin: 6px 2px;">
+                <b>Note:</b> The super cell settings here are <b>for visualization
+                purposes only</b>. To simulate a super cell, open the <b>Edit
+                structure</b> panel below, navigate to the <b>Edit cell</b> tab, and
+                use the <b>Cell transformation</b> controls.
+            </div>
+        """)
+
         return ipw.VBox(
             [
                 supercell_selector,
+                info,
                 background_color,
                 camera_type,
                 center_button,


### PR DESCRIPTION
This PR aims to emphasize the distinction between visualizing the super cell and actually transforming it. It does so by (i) wrapping the viewer in its own accordion titled "View structure", and (ii) adding a comment below the super cell control in the appearance tab of the viewer clarifying usage.

Closes #667