### PR TITLE
Remove sklearn dependency.

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -751,11 +751,6 @@ class SmilesWidget(ipw.VBox):
 
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""
-        from sklearn.decomposition import PCA
-
-        # Get the principal axes and realign the molecule along z-axis.
-        if len(species) > 2:
-            positions = PCA(n_components=3).fit_transform(positions)
         atoms = ase.Atoms(species, positions=positions, pbc=False)
         atoms.cell = np.ptp(atoms.positions, axis=0) + 10
         atoms.center()

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,6 @@ eln =
     requests-cache~=1.0
 smiles =
     rdkit>=2021.09.2
-    scikit-learn~=1.1
 docs =
     sphinx~=7.3
     sphinx-design~=0.5


### PR DESCRIPTION
fixes #590 

Sklearn was only used to align SMILES-generated molecules with the Z-axis. The usefulness of such functionality is questionable, and it doesn't justify depending on such a heavy library.