### PR TITLE
CI: Pin Ubuntu version to fix Firefox installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 env:
     FORCE_COLOR: "1"
-    UV_VERSION: "0.4.6"
+    UV_VERSION: "0.5.28"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -27,10 +27,10 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                aiida-core-version: [2.1.2, 2.6.2]
+                aiida-core-version: [2.1.2, 2.6.3]
             fail-fast: false
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         timeout-minutes: 30
 
         steps:
@@ -90,10 +90,10 @@ jobs:
             matrix:
                 python-version: ['3.9', '3.11']
                 # Test on the latest and oldest supported version
-                aiida-core-version: [2.2.2, 2.6.2]
+                aiida-core-version: [2.2.2, 2.6.3]
             fail-fast: false
 
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
         timeout-minutes: 30
         services:
             rabbitmq:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     build:
 
         name: Build package
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         steps:
 
@@ -52,7 +52,7 @@ jobs:
         if: github.repository_owner == 'aiidalab'
 
         needs: [build]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         environment:
             name: Test PyPI
@@ -79,7 +79,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v') && github.repository_owner == 'aiidalab'
 
         needs: [build, publish-test]
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04
 
         environment:
             name: PyPI


### PR DESCRIPTION
Pinning the ubuntu version to 22.04 as the CI runner seems to fix the Firefox installation, see #672 for details. At some point we should probably bump the Firefox version that we use (and that would supposedly work with newer Ubuntu) but this is the fastest fix for now.

I also changed all the other `ubuntu-latest` to `ubuntu-24.04` as a best practice to prevent this kind of issues in the future.

Also bump uv and aiida-core versions to latest.