### PR TITLE
Add ipython as a direct dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     spglib>=1.14,<3
     vapory~=0.1.2
     pandas~=2.1
+    ipython>=7.33
 python_requires = >=3.9
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
We import from ipython directly in a bunch of places (e.g. `from IPython.display import Javascript, display`) so we should declare it as a direct dependency.

I've determined the minimum version by looking at a version in a very old aiidalab image.

```
docker run docker.io/aiidalab/full-stack:aiida-2.1.2 pip show ipython
```

Part of #392 