### PR TITLE
Wrap structure importers in accordion panel

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -114,15 +114,9 @@ class StructureManagerWidget(ipw.VBox):
                 f"Unknown data format '{node_class}'. Options: {list(self.SUPPORTED_DATA_FORMATS.keys())}"
             )
 
-        structure_importers = self._structure_importers(importers)
-
         select_panel = ipw.Accordion(
-            children=[
-                *structure_importers,
-            ]
-            if structure_importers
-            else [],
-            selected_index=0 if structure_importers else None,
+            children=self._structure_importers(importers),
+            selected_index=0 if importers else None,
         )
         select_panel.set_title(0, "Select structure")
 
@@ -183,12 +177,6 @@ class StructureManagerWidget(ipw.VBox):
 
         if not importers:
             return []
-
-        # If there is only one importer - no need to make tabs.
-        if len(importers) == 1:
-            # Assigning a function which will be called when importer provides a structure.
-            tl.dlink((importers[0], "structure"), (self, "input_structure"))
-            return [importers[0]]
 
         # Otherwise making one tab per importer.
         importers_tab = ipw.Tab()


### PR DESCRIPTION
Following #666, I make structure selection consistent with viewing and editing, as well as guard against no importers following #681.

@giovannipizzi by request, I had wrapped the viewer in an accordion panel (opened by default) in #666. Here I'm extending it to the selectors. Question, should we keep this "Select structure" accordion panel open on start?

---

![image](https://github.com/user-attachments/assets/97e5212f-1da3-4ca5-b7b4-799bd0308e72)