### PR TITLE
Implement caching in `AiidaNodeViewWidget`

### DIFF
--- a/aiidalab_widgets_base/static/styles/global.css
+++ b/aiidalab_widgets_base/static/styles/global.css
@@ -1,0 +1,7 @@
+.aiida-node-view-widget {
+  border: var(--jp-widgets-border-width) solid var(--jp-border-color1);
+  padding: 12px;
+  margin: 2px;
+  height: auto;
+  width: auto;
+}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from aiidalab_widgets_base.loaders import LoadingWidget
 from aiidalab_widgets_base.utils.loaders import load_css
 
 
@@ -8,3 +9,12 @@ def test_load_css():
     css_dir = Path("aiidalab_widgets_base/static/styles")
     load_css(css_path=css_dir)
     load_css(css_path=css_dir / "global.css")
+
+
+def test_loading_widget():
+    """Test `LoadingWidget`."""
+    widget = LoadingWidget(message="Loading some widget")
+    assert widget.message.value == "Loading some widget"
+    assert widget.children[0].value == "Loading some widget"
+    assert widget.children[1].value == "<i class='fa fa-spinner fa-spin fa-2x fa-fw'/>"
+    assert "loading" in widget._dom_classes

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -313,3 +313,31 @@ def test_loading_viewer_using_process_type(generate_calc_job_node):
         "Viewer is not an instance of the expected viewer class."
     )
     assert viewer.node == process, "Viewer's node does not match the test process node."
+
+
+def test_node_view_for_non_widget_viewer():
+    """Test that a node with no registered viewer is displayed in an output widget"""
+    import sys
+    from io import StringIO
+
+    # Intercepting stdout because `ipw.Output` does not
+    # store outputs in non-interactive environments.
+    captured = StringIO()
+    sys.stdout = captured
+
+    node_view = viewers.AiidaNodeViewWidget()
+    node = orm.Int(1)
+    node_view.node = node
+    assert node_view.children[0] is node_view._output
+    assert str(node) in sys.stdout.getvalue()
+
+
+def test_node_view_caching():
+    """Test that providing a given node a second time returns the cached viewer."""
+    node_view = viewers.AiidaNodeViewWidget()
+    node = orm.Int(1)
+    node_view.node = node
+    viewer = node_view.children[0]
+    node_view.node = None
+    node_view.node = node
+    assert node_view.children[0] is viewer


### PR DESCRIPTION
Moving node view caching mechanism implemented by @superstar54 in the QE app (https://github.com/aiidalab/aiidalab-qe/pull/921) into `AiidaNodeViewWidget`