### PR TITLE
Fix password input

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1858,7 +1858,7 @@ class ResourceSetupBaseWidget(ipw.VBox):
         if change["new"]:
             self.detailed_setup_widget.layout.display = "block"
             self.quick_setup_button.disabled = True
-            #reset and trigger the verification mode to update the password box.
+            # reset and trigger the verification mode to update the password box.
             self.ssh_computer_setup._verification_mode.value = "private_key"
             self.ssh_computer_setup._verification_mode.value = "password"
             # fill the template variables with the default values or the filled values.

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1792,6 +1792,12 @@ class ResourceSetupBaseWidget(ipw.VBox):
                 detailed_setup,
             ]
         )
+        # hide this conatainer if the detailed setup is enabled.
+        self.password_box_container = ipw.VBox(
+            children=[
+                self.ssh_computer_setup.password_box,
+            ]
+        )
 
         super().__init__(
             children=[
@@ -1803,7 +1809,7 @@ class ResourceSetupBaseWidget(ipw.VBox):
                 self.template_computer_setup,
                 self.template_code,
                 self.template_computer_configure,
-                self.ssh_computer_setup.password_box,
+                self.password_box_container,
                 self.detailed_setup_switch_widgets,
                 ipw.HBox(
                     children=[
@@ -1823,9 +1829,9 @@ class ResourceSetupBaseWidget(ipw.VBox):
         """Update the layout to hide or show the bundled quick_setup/detailed_setup."""
         # check if the password is asked for ssh connection.
         if self.ssh_auth != "password":
-            self.ssh_computer_setup.password_box.layout.display = "none"
+            self.password_box_container.layout.display = "none"
         else:
-            self.ssh_computer_setup.password_box.layout.display = "block"
+            self.password_box_container.layout.display = "block"
 
         # If both quick and detailed setup are enabled
         # - show the switch widget
@@ -1858,15 +1864,15 @@ class ResourceSetupBaseWidget(ipw.VBox):
         if change["new"]:
             self.detailed_setup_widget.layout.display = "block"
             self.quick_setup_button.disabled = True
-            # update the password box.
-            if self.ssh_auth is None or self.ssh_auth == "password":
-                self.ssh_computer_setup._verification_mode.value = "password"
-                self.ssh_computer_setup.password_box.layout.display = "block"
+            # hide the password box in the quick setup, because user will input
+            # the password in the detailed setup
+            self.password_box_container.layout.display = "none"
             # fill the template variables with the default values or the filled values.
             # If the template variables are not all filled raise a warning.
         else:
             self.detailed_setup_widget.layout.display = "none"
             self.quick_setup_button.disabled = False
+            # this will update the password box based on the template computer_configure.
             self._update_layout()
 
     def _on_template_computer_configure_metadata_change(self, change):

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1792,7 +1792,7 @@ class ResourceSetupBaseWidget(ipw.VBox):
                 detailed_setup,
             ]
         )
-        # hide this conatainer if the detailed setup is enabled.
+        # This container is used to control the appearance of the password box
         self.password_box_container = ipw.VBox(
             children=[
                 self.ssh_computer_setup.password_box,

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -364,6 +364,7 @@ class SshComputerSetup(ipw.VBox):
             self.proxy_jump,
             self.proxy_command,
             self._verification_mode,
+            self.password_box,
             self._verification_mode_output,
             btn_setup_ssh,
         ]
@@ -613,9 +614,13 @@ class SshComputerSetup(ipw.VBox):
         """which verification mode is chosen."""
         with self._verification_mode_output:
             clear_output()
-            if self._verification_mode.value == "private_key":
+            if self._verification_mode.value == "password":
+                self.password_box.layout.display = "block"
+            elif self._verification_mode.value == "private_key":
                 display(self._inp_private_key)
+                self.password_box.layout.display = "none"
             elif self._verification_mode.value == "public_key":
+                self.password_box.layout.display = "none"
                 public_key = self._ssh_folder / "id_rsa.pub"
                 if public_key.exists():
                     display(
@@ -1853,6 +1858,9 @@ class ResourceSetupBaseWidget(ipw.VBox):
         if change["new"]:
             self.detailed_setup_widget.layout.display = "block"
             self.quick_setup_button.disabled = True
+            #reset and trigger the verification mode to update the password box.
+            self.ssh_computer_setup._verification_mode.value = "private_key"
+            self.ssh_computer_setup._verification_mode.value = "password"
             # fill the template variables with the default values or the filled values.
             # If the template variables are not all filled raise a warning.
         else:

--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -1858,14 +1858,16 @@ class ResourceSetupBaseWidget(ipw.VBox):
         if change["new"]:
             self.detailed_setup_widget.layout.display = "block"
             self.quick_setup_button.disabled = True
-            # reset and trigger the verification mode to update the password box.
-            self.ssh_computer_setup._verification_mode.value = "private_key"
-            self.ssh_computer_setup._verification_mode.value = "password"
+            # update the password box.
+            if self.ssh_auth is None or self.ssh_auth == "password":
+                self.ssh_computer_setup._verification_mode.value = "password"
+                self.ssh_computer_setup.password_box.layout.display = "block"
             # fill the template variables with the default values or the filled values.
             # If the template variables are not all filled raise a warning.
         else:
             self.detailed_setup_widget.layout.display = "none"
             self.quick_setup_button.disabled = False
+            self._update_layout()
 
     def _on_template_computer_configure_metadata_change(self, change):
         """callback when the metadata of computer_configure template is changed."""

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -24,6 +24,8 @@ def test_ssh_computer_setup_widget(monkeypatch, tmp_path):
     # mock home directory for ssh config file
     monkeypatch.setenv("HOME", str(tmp_path))
     widget = computational_resources.SshComputerSetup()
+    # password box show by default in the SshComputerSetup
+    assert widget.password_box.layout.display != "none"
 
     ssh_config = {
         "hostname": "daint.cscs.ch",
@@ -588,6 +590,9 @@ def test_resource_setup_widget_for_password_configure(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
 
     w = ResourceSetupBaseWidget()
+
+    # password box hide by default in the ResourceSetupBaseWidget
+    assert w.ssh_computer_setup.password_box.layout.display == "none"
 
     # Test select a new resource setup will update the output interface (e.g. ssh_config, computer_setup, code_setup)
     # and the computer/code setup widget will be updated accordingly.

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -557,7 +557,7 @@ def test_resource_setup_widget_default():
     w.ssh_computer_setup.username.value = "aiida"
 
     # Since cscs is 2FA, test the password box is not displayed.
-    assert w.ssh_computer_setup.password_box.layout.display == "none"
+    assert w.password_box_container.layout.display == "none"
 
     w._on_quick_setup()
 
@@ -591,15 +591,6 @@ def test_resource_setup_widget_for_password_configure(monkeypatch, tmp_path):
 
     w = ResourceSetupBaseWidget()
 
-    # password box hide by default in the ResourceSetupBaseWidget
-    assert w.ssh_computer_setup.password_box.layout.display == "none"
-    # click the toggle detail setup button to show the detail setup
-    w.toggle_detail_setup.value = True
-    assert w.ssh_computer_setup.password_box.layout.display == "block"
-    # hide the detail setup
-    w.toggle_detail_setup.value = False
-    assert w.ssh_computer_setup.password_box.layout.display == "none"
-
     # Test select a new resource setup will update the output interface (e.g. ssh_config, computer_setup, code_setup)
     # and the computer/code setup widget will be updated accordingly.
     w.comp_resources_database.domain_selector.value = "merlin.psi.ch"
@@ -618,7 +609,16 @@ def test_resource_setup_widget_for_password_configure(monkeypatch, tmp_path):
             assert sub_widget.value == "merlin-cpu"
 
     # Test the password box is displayed.
-    assert w.ssh_computer_setup.password_box.layout.display == "block"
+    assert w.password_box_container.layout.display == "block"
+
+    # click the toggle detail setup button to show the detail setup
+    # the password box container should be hidden
+    w.toggle_detail_setup.value = True
+    assert w.password_box_container.layout.display == "none"
+    # hide the detail setup
+    # the password box container should be shown
+    w.toggle_detail_setup.value = False
+    assert w.password_box_container.layout.display == "block"
 
     # Fill the computer configure template variables
     for (
@@ -659,7 +659,7 @@ def test_resource_setup_widget_for_password_configure(monkeypatch, tmp_path):
 
     # After reset the password box should be hidden again.
     w.reset()
-    assert w.ssh_computer_setup.password_box.layout.display == "none"
+    assert w.password_box_container.layout.display == "none"
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -593,6 +593,12 @@ def test_resource_setup_widget_for_password_configure(monkeypatch, tmp_path):
 
     # password box hide by default in the ResourceSetupBaseWidget
     assert w.ssh_computer_setup.password_box.layout.display == "none"
+    # click the toggle detail setup button to show the detail setup
+    w.toggle_detail_setup.value = True
+    assert w.ssh_computer_setup.password_box.layout.display == "block"
+    # hide the detail setup
+    w.toggle_detail_setup.value = False
+    assert w.ssh_computer_setup.password_box.layout.display == "none"
 
     # Test select a new resource setup will update the output interface (e.g. ssh_config, computer_setup, code_setup)
     # and the computer/code setup widget will be updated accordingly.


### PR DESCRIPTION
Fix #691 .
As a user, I want to set up my own HPC, since the HPC is not in the domain, so I clicked the detailed step, but I can not input the password. Here is the screenshot of the bug:

![image](https://github.com/user-attachments/assets/e6ad3588-b2e4-4632-b610-840cbd5e5cdd)


Here is a quick fix:

![image](https://github.com/user-attachments/assets/34f48a57-fc18-4ddd-b021-7df3063134da)
