### PR TITLE
Pin ipython version to <9.0

### DIFF
--- a/aiidalab_widgets_base/bug_report.py
+++ b/aiidalab_widgets_base/bug_report.py
@@ -11,11 +11,11 @@ import base64
 import json
 import platform
 import re
+import subprocess
 import sys
+import textwrap
 import zlib
-from subprocess import run
-from textwrap import wrap
-from urllib.parse import urlencode, urlsplit, urlunsplit
+from urllib import parse
 
 import ipywidgets as ipw
 from ansi2html import Ansi2HTMLConverter
@@ -25,7 +25,7 @@ def find_installed_packages(python_bin: str | None = None) -> dict[str, str]:
     """Return all currently installed packages."""
     if python_bin is None:
         python_bin = sys.executable
-    output = run(
+    output = subprocess.run(
         [python_bin, "-m", "pip", "list", "--format=json"],
         encoding="utf-8",
         capture_output=True,
@@ -185,13 +185,15 @@ def install_create_github_issue_exception_handler(output, url, labels=None):
                     # Determine and format the environment fingerprint to be
                     # included with the bug report:
                     environment_fingerprint="\n".join(
-                        wrap(get_environment_fingerprint().decode("utf-8"), 100)
+                        textwrap.wrap(
+                            get_environment_fingerprint().decode("utf-8"), 100
+                        )
                     ),
                 ),
                 "labels": ",".join(labels),
             }
-            issue_url = urlunsplit(
-                urlsplit(url)._replace(query=urlencode(bug_report_query))
+            issue_url = parse.urlunsplit(
+                parse.urlsplit(url)._replace(query=parse.eurlencode(bug_report_query))
             )
 
             with output:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     spglib>=1.14,<3
     vapory~=0.1.2
     pandas~=2.1
-    ipython>=7.33
+    ipython>=7.33,<9.0
 python_requires = >=3.9
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Pin `ipython` package to `<9.0` to fix a failing test. The pin may be removed once we update bokeh (I'll open a separate issue to track that work).

I used the first commit with some small import changes in `bug_report.py` to trigger CI to verify that it fail.

Closes #699