### PR TITLE
Fix `ipyoptimade` version

### DIFF
--- a/aiidalab_widgets_base/databases.py
+++ b/aiidalab_widgets_base/databases.py
@@ -189,10 +189,6 @@ class OptimadeQueryWidget(ipw.VBox):
             skip_providers=kwargs.pop(
                 "skip_providers", default_parameters.SKIP_DATABASE
             ),
-            provider_database_groupings=kwargs.pop(
-                "provider_database_groupings",
-                default_parameters.PROVIDER_DATABASE_GROUPINGS,
-            ),
         )
         filters = query_filter.OptimadeQueryFilterWidget(
             embedded=embedded,

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ dev =
     pytest-timeout~=2.3.0
     selenium~=4.23.0
 optimade =
-    ipyoptimade~=0.1
+    ipyoptimade>=1.2.1,<2
 eln =
     aiidalab-eln>=0.1.2,~=0.1
     requests-cache~=1.0


### PR DESCRIPTION
Recent changes to Materials Cloud and/or the OPTIMADE client have broken the `OptimadeQueryWidget`. This PR updates the `ipyoptimade` dependency and fixes the use of the package in the widget, restoring access to the Materials Cloud database.