### PR TITLE
Avoid storing default user email if not fetching codes

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -96,7 +96,8 @@ class ComputationalResourcesWidget(ipw.VBox):
             self.refresh, names=["allow_disabled_computers", "allow_hidden_codes"]
         )
 
-        self._default_user_email = orm.User.collection.get_default().email
+        if fetch_codes:
+            self._default_user_email = orm.User.collection.get_default().email
 
         selection_row = ipw.HBox(
             children=[
@@ -138,7 +139,10 @@ class ComputationalResourcesWidget(ipw.VBox):
 
     def _get_codes(self):
         """Query the list of available codes."""
-        user = orm.User.collection.get(email=self._default_user_email)
+        if hasattr(self, "_default_user_email"):
+            user = orm.User.collection.get(email=self._default_user_email)
+        else:
+            user = orm.User.collection.get_default()
 
         filters = (
             {"attributes.input_plugin": self.default_calc_job_plugin}


### PR DESCRIPTION
In #543, we opted to replacing direct default user fetching with fetching via the user's email, to avoid thread issues.
Since, #646 made code fetching optional in `ComputationalResourcesWidget`. However, the storing of the default user's email was no guarded. This PR remedies this.
#646 was introduced, as at least the in the QE app, which has moved towards MVC design, now handles its own code fetching.
However, it appears that even the storing of the default user's email introduces a threading issue (see https://github.com/aiidalab/aiidalab-qe/issues/1391).