### PR TITLE
Use widget's `message` as the child

### DIFF
--- a/aiidalab_widgets_base/loaders.py
+++ b/aiidalab_widgets_base/loaders.py
@@ -4,11 +4,11 @@ import ipywidgets as ipw
 class LoadingWidget(ipw.HBox):
     """Widget for displaying a loading spinner."""
 
-    def __init__(self, message="Loading", **kwargs):
+    def __init__(self, message: str = "Loading", **kwargs):
         self.message = ipw.Label(message)
         super().__init__(
             children=[
-                ipw.Label(message),
+                self.message,
                 ipw.HTML(
                     value="<i class='fa fa-spinner fa-spin fa-2x fa-fw'/>",
                     layout=ipw.Layout(margin="12px 0 6px"),


### PR DESCRIPTION
Stored the widget's message in a label, but was using anothe label as the child. Fixed here.