### PR TITLE
fix bug if No symmetry from spglib

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -735,8 +735,12 @@ class _StructureDataBaseViewer(ipw.VBox):
                 (False, True, True): "yz",
                 (False, False, False): "-",
             }
-            self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
-            self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
+            try:
+                self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
+                self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
+            except TypeError:
+                self.cell_spacegroup.value = "Spacegroup: -"
+                self.cell_hall.value = "Hall: -"
             self.periodicity.value = (
                 f"Periodicity: {periodicity_map[tuple(self.structure.pbc)]}"
             )

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -735,10 +735,10 @@ class _StructureDataBaseViewer(ipw.VBox):
                 (False, True, True): "yz",
                 (False, False, False): "-",
             }
-            try:
+            if symmetry_dataset is not None:
                 self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
                 self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
-            except TypeError:
+            else:
                 self.cell_spacegroup.value = "Spacegroup: -"
                 self.cell_hall.value = "Hall: -"
             self.periodicity.value = (


### PR DESCRIPTION
Geometries with no simmetry were crashing the viewer, see attached example
```
~/opt/aiidalab-widgets-base/aiidalab_widgets_base/viewers.py in _observe_cell(self, _)
    735                 (False, False, False): "-",
    736             }
--> 737             self.cell_spacegroup.value = f"Spacegroup: {symmetry_dataset['international']} (No.{symmetry_dataset['number']})"
    738             self.cell_hall.value = f"Hall: {symmetry_dataset['hall']} (No.{symmetry_dataset['hall_number']})"
    739             self.periodicity.value = (

TypeError: 'NoneType' object is not subscriptable
```

```
43
Lattice="12.38439583333335 0.0 0.0 0.0 26.474999983589985 0.0 0.0 0.0 15.0" Properties=species:S:1:pos:R:3:_aiidalab_viewer_representation_default:I:1 pbc="T T T"
C        0.61917014      12.87999998       7.50000000        0
C        1.85751042      13.59499998       7.50000000        0
C        3.09585069      12.87999998       7.50000000        0
C        3.09585069      11.44999998       7.50000000        0
C        1.85751042      10.73499998       7.50000000        0
C        0.61917014      11.44999998       7.50000000        0
C        4.33518403      10.73499998       7.50000000        0
C        4.33518403       9.30499998       7.50000000        0
C        3.09585069       8.58999998       7.50000000        0
C        1.85751042       9.30499998       7.50000000        0
C        4.33518403      13.59499998       7.50000000        0
C        5.57352431      12.87999998       7.50000000        0
C        5.57352431      11.44999998       7.50000000        0
C        6.81186458      13.59499998       7.50000000        0
C        6.81186458      15.02499998       7.50000000        0
C        8.05020486      15.73999998       7.50000000        0
C        9.28854514      15.02499998       7.50000000        0
C        9.28854514      13.59499998       7.50000000        0
C        8.05020486      12.87999998       7.50000000        0
C       10.52688542      15.73999998       7.50000000        0
C       11.76522569      15.02499998       7.50000000        0
C       11.76522569      13.59499998       7.50000000        0
C       10.52688542      12.87999998       7.50000000        0
C        8.05020486      17.16999998       7.50000000        0
C        9.28854514      17.88499998       7.50000000        0
C       10.52688542      17.16999998       7.50000000        0
H        0.32480480      15.56998743       7.50000000        0
H        1.85751042      14.68499998       7.50000000        0
H        5.27906438       8.75984874       7.50000000        0
H        3.09566155       7.50000000       7.50000000        0
H        0.91353548       8.76001253       7.50000000        0
H        4.33537317      14.68499997       7.50000000        0
H        6.51749924      10.90501253       7.50000000        0
H        5.86788965      15.56998743       7.50000000        0
H        8.05020486      11.78999998       7.50000000        0
H       10.52688542      11.78999998       7.50000000        0
H        7.10622992      17.71498743       7.50000000        0
H        9.28854514      18.97499998       7.50000000        0
H       11.07669427      17.48742253       8.39830571        0
H       11.07669427      17.48742253       6.60169429        0
H       12.05959104      10.90501253       7.50000000        0
H       -0.32480480      10.90501253       7.50000000        0
H       12.70920063      15.56998743       7.50000000        0
```