### PR TITLE
Revert "Migrate to ipywidgets 8.x (#644)"

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -117,8 +117,8 @@ class StructureManagerWidget(ipw.VBox):
         select_panel = ipw.Accordion(
             children=self._structure_importers(importers),
             selected_index=0 if importers else None,
-            titles=["Import structure"] if importers else [],
         )
+        select_panel.set_title(0, "Select structure")
 
         view_panel = ipw.Accordion(
             children=[
@@ -153,8 +153,8 @@ class StructureManagerWidget(ipw.VBox):
             if structure_editors
             else [],
             selected_index=None,
-            titles=["Edit structure"] if structure_editors else [],
         )
+        edit_panel.set_title(0, "Edit structure")
 
         self.output = ipw.HTML("")
 
@@ -423,9 +423,10 @@ class StructureUploadWidget(ipw.VBox):
 
     def _on_file_upload(self, change=None):
         """When file upload button is pressed."""
-        assert len(change["new"]) == 1, "Only single file upload is supported."
-        file = change["new"][0]
-        self.structure = self._read_structure(file["name"], file["content"])
+        for fname, item in change["new"].items():
+            self.structure = self._read_structure(fname, item["content"])
+            self.file_upload.value.clear()
+            break
 
     def _read_structure(self, fname, content):
         suffix = "".join(pathlib.Path(fname).suffixes)

--- a/aiidalab_widgets_base/wizard.py
+++ b/aiidalab_widgets_base/wizard.py
@@ -102,6 +102,7 @@ class WizardAppWidget(ipw.VBox):
         # Initialize the accordion with the widgets ...
         self.accordion = ipw.Accordion(children=widgets)
         self._update_titles()
+        ipw.link((self.accordion, "selected_index"), (self, "selected_index"))
 
         # Watch for changes to each step's state
         for widget in widgets:
@@ -141,14 +142,11 @@ class WizardAppWidget(ipw.VBox):
         )
         self.next_button.on_click(self._on_click_next_button)
 
-        # Link the selected_index of the accordion to this app's selected_index.
-        # This needs to happen after all affected widgets have been created.
-        ipw.link((self.accordion, "selected_index"), (self, "selected_index"))
-
         self.header = ipw.HBox(
             children=[self.back_button, self.reset_button, self.next_button]
         )
         self.show_header = show_header
+
         super().__init__(children=[self.header, self.accordion], **kwargs)
 
     @property

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ install_requires =
     humanfriendly~=10.0
     ipytree~=0.2
     traitlets~=5.4
-    ipywidgets~=8.1
+    ipywidgets~=7.7
+    widgetsnbextension<3.6.3
     pymysql~=0.9
     nglview~=3.0,>=3.0.8
     spglib>=1.14,<3

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -36,11 +36,9 @@ def test_open_aiida_node_in_app_widget(multiply_add_completed_workchain):
 
     open_node_in_app.node = process
 
-    assert len(open_node_in_app.tab.children) == 3
-    expected_tab_titles = [
-        "Geometry Optimization",
-        "Geometry analysis",
-        "Isotherm",
-    ]
-    for i, title in enumerate(expected_tab_titles):
-        assert open_node_in_app.tab.get_title(i) == title
+    assert len(open_node_in_app.tab.children) > 0
+    assert open_node_in_app.tab._titles == {
+        "0": "Geometry Optimization",
+        "1": "Geometry analysis",
+        "2": "Isotherm",
+    }

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -146,16 +146,15 @@ def test_structure_upload_widget():
     # Simulate the structure upload.
     widget._on_file_upload(
         change={
-            "new": (
-                {
-                    "name": "test.xyz",
+            "new": {
+                "test.xyz": {
                     "content": b"""2
 
                 Si 0.0 0.0 0.0
                 Si 0.5 0.5 0.5
                 """,
-                },
-            )
+                }
+            }
         }
     )
     assert isinstance(widget.structure, ase.Atoms)

--- a/tests/test_wizard.py
+++ b/tests/test_wizard.py
@@ -65,12 +65,12 @@ def test_wizard_app_widget():
     # Check initial state.
     assert s1.state == s1.State.INIT
     assert s2.state == s2.State.INIT
+    assert widget.accordion.selected_index == 0
     assert widget.next_button.disabled is True
     assert widget.back_button.disabled is True
     assert widget.accordion.get_title(0) == "○ Step 1: Setup"
     assert widget.accordion.get_title(1) == "○ Step 2: View results"
     assert not widget.can_reset()
-    widget.accordion.selected_index = 0  # Ensure first step is selected.
 
     # Check state after finishing the first step.
     s1.order_button.click()

--- a/tests_notebooks/test_notebooks.py
+++ b/tests_notebooks/test_notebooks.py
@@ -40,12 +40,12 @@ def test_eln_configure(selenium_driver, final_screenshot):
 
 def test_process(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/process.ipynb")
-    driver.find_element(By.XPATH, '//label[text()="Select calculation:"]')
+    driver.find_element(By.XPATH, '//label[@title="Select calculation:"]')
 
 
 def test_wizard_apps(selenium_driver, final_screenshot):
     driver = selenium_driver("notebooks/wizard_apps.ipynb")
-    driver.find_element(By.XPATH, '//label[text()="Delivery progress:"]')
+    driver.find_element(By.XPATH, '//label[@title="Delivery progress:"]')
 
 
 def test_structures(selenium_driver, final_screenshot):


### PR DESCRIPTION
Unfortunately, bumping ipywidgets here without bumping them in aiidalab-home broke the aiidalab-docker-stack build since we do integration tests against the AWB master branch. 

Testing against master branch is perhaps not the greatest idea, but since i anyway wanted to make a 2.6 AWB release, let's revert #644 for now, and we can land it back once we have the aiidalab-home stuff figured out. 

This will unblock aiidalab-docker-stack release with aiida-core 2.7.2 which contains a bunch of important bugfixes.

This reverts commit 457b721924ce713f9f26acf2c826bd82c2095fc7.