### PR TITLE
Bump version v2.4.0 -> v2.5.0

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -131,4 +131,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "2.4.0"
+__version__ = "2.5.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ docs =
 aiidalab_widgets_base.static.styles = *.css
 
 [bumpver]
-current_version = "v2.4.0"
+current_version = "v2.5.0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
# Release notes

<!-- Release notes generated using configuration in .github/release.yml at v2.5.0 -->

## What's Changed
### Breaking Changes 🛠
* Remove private key upload functionality by @edan-bainglass in https://github.com/aiidalab/aiidalab-widgets-base/pull/690

We've removed the functionality to upload private SSH keys due to (obvious) security concerns. 
Users who know what they're doing can still upload arbitrary files via File Manager accessible from the Home app.

### New Features 🎉
* Update StructureViewer units by @mikibonacci in https://github.com/aiidalab/aiidalab-widgets-base/pull/694

### Bug fixes 🐛
* Fix password input by @superstar54 in https://github.com/aiidalab/aiidalab-widgets-base/pull/692
* Fix typo in bug report by @edan-bainglass in https://github.com/aiidalab/aiidalab-widgets-base/pull/702
* Fix `ipyoptimade` version by @edan-bainglass in https://github.com/aiidalab/aiidalab-widgets-base/pull/703

### Documentation 📝
* Document the SSH setup widget by @edan-bainglass in https://github.com/aiidalab/aiidalab-widgets-base/pull/695

### Other Changes
* Pin ipython version to <9.0 by @danielhollas in https://github.com/aiidalab/aiidalab-widgets-base/pull/700
* Test aiida 2.7 by @danielhollas in https://github.com/aiidalab/aiidalab-widgets-base/pull/698
* CI: Use uv to test with lowest supported dependency versions by @danielhollas in https://github.com/aiidalab/aiidalab-widgets-base/pull/714


**Full Changelog**: https://github.com/aiidalab/aiidalab-widgets-base/compare/v2.4.0...v2.5.0