### PR TITLE
Don't test with Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                docker-tag: [aiida-2.7.2]
+                docker-tag: [aiida-2.7.3]
             fail-fast: false
 
         runs-on: ubuntu-22.04
@@ -40,7 +40,7 @@ jobs:
             - name: Set up Python
               uses: actions/setup-python@v6
               with:
-                  python-version: '3.11'
+                  python-version: '3.12'
 
             - name: Setup uv
               uses: astral-sh/setup-uv@v7
@@ -87,7 +87,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.11', '3.12']
+                python-version: ['3.9', '3.12']
                 # Test latest and oldest supported package versions
                 uv-resolution: ['lowest-direct', 'highest']
             fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                docker-tag: [aiida-2.7.3]
+                docker-tag: [aiida-2.7.2]
             fail-fast: false
 
         runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
 
             - uses: actions/checkout@v6
 
-            - name: Set up Python 3.10
+            - name: Set up Python 3.12
               uses: actions/setup-python@v6
               with:
-                  python-version: '3.10'
+                  python-version: '3.12'
 
             - name: Install pypa/build
               run: python -m pip install build


### PR DESCRIPTION
We're jumping all the way to 3.12 so there's no point in running unit tests with Python 3.11