### PR TITLE
Pin numpy to 1.x due to bokeh incompatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     ansi2html~=1.7
     ase~=3.18
     bokeh~=2.4
+    numpy~=1.26
     humanfriendly~=10.0
     ipytree~=0.2
     traitlets~=5.4


### PR DESCRIPTION
The currently pinned bokeh version is incompatible with numpy 2.x. Since aiida-core 2.8 started supporting numpy 2.x, widget tests using bokeh started failing.

We will also need to pin numpy in the image based on aiida-core 2.8 in order not to break older apps.

See #733 for more details 