### PR TITLE
Bump version v2.5.0 -> v3.0.0a0

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -117,4 +117,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "2.5.0"
+__version__ = "3.0.0a0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ docs =
 aiidalab_widgets_base.static.styles = *.css
 
 [bumpver]
-current_version = "v2.5.0"
+current_version = "v3.0.0a0"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
Let's release a 3 alpha version for an easier testing with the nbclassic image

(needs to be merged with a merged commit!)