### PR TITLE
Fix CI: Pin RabbitMQ version and update requests-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         timeout-minutes: 30
         services:
             rabbitmq:
-                image: rabbitmq:latest
+                image: rabbitmq:4.2
                 ports:
                     - 5672:5672
         steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ optimade =
     ipyoptimade>=1.2.1,<2
 eln =
     aiidalab-eln>=0.1.2,~=0.1
-    requests-cache~=1.0
+    requests-cache>=1.3.2,~=1.3
 smiles =
     rdkit>=2021.09.2
 docs =


### PR DESCRIPTION
Two fixes here, originally identified by @cpignedoli in #712

1.  It looks like RMQ v4.3 broke AiiDA so pin to v4.2 for now. I'll open an issue on aiida-core.

2. `requests=2.34` release broke `requests-cache` package. The fix was release in v1.3.2, so we set it as minimum version. See https://github.com/requests-cache/requests-cache/issues/1151 for details 
(`requests-cache` is only needed by the `eln` extras, which should hopefully be removed soon, before we release v3.)