### PR TITLE
Clear stale bond shapes from structure viewer

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -1050,9 +1050,10 @@ class _StructureDataBaseViewer(ipw.VBox):
 
     def remove_viewer_components(self, c=None):
         """Remove all components from the viewer except the one specified."""
-        if hasattr(self._viewer, "component_0"):
-            self._viewer.component_0.clear_representations()
-            cid = self._viewer.component_0.id
+        keep_id = getattr(c, "id", c)
+        for cid in list(self._viewer._ngl_component_ids):
+            if cid == keep_id:
+                continue
             self._viewer.remove_component(cid)
 
     @tl.default("supercell")

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -1048,12 +1048,9 @@ class _StructureDataBaseViewer(ipw.VBox):
                     kwargs=params["params"],
                 )
 
-    def remove_viewer_components(self, c=None):
-        """Remove all components from the viewer except the one specified."""
-        keep_id = getattr(c, "id", c)
+    def remove_viewer_components(self):
+        """Remove all components from the viewer."""
         for cid in list(self._viewer._ngl_component_ids):
-            if cid == keep_id:
-                continue
             self._viewer.remove_component(cid)
 
     @tl.default("supercell")

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -292,7 +292,6 @@ def test_structure_data_viewer_clears_bond_shape_components():
 
     viewer.structure = water
     assert len(viewer._viewer._ngl_component_ids) == 2
-    assert "nglview.shape.Shape" in viewer._viewer._ngl_component_names
 
     viewer.structure = None
 

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -279,6 +279,28 @@ def test_structure_data_viewer_representation(structure_data_object):
         v.structure = orm.Int(1)
 
 
+def test_structure_data_viewer_clears_bond_shape_components():
+    water = ase.Atoms(
+        symbols=["O", "H", "H"],
+        positions=[
+            (0.0, 0.0, 0.119262),
+            (0.0, 0.763239, -0.477047),
+            (0.0, -0.763239, -0.477047),
+        ],
+    )
+    viewer = viewers.StructureDataViewer()
+
+    viewer.structure = water
+    assert len(viewer._viewer._ngl_component_ids) == 2
+    assert "nglview.shape.Shape" in viewer._viewer._ngl_component_names
+
+    viewer.structure = None
+
+    assert viewer.displayed_structure is None
+    assert viewer._viewer._ngl_component_ids == []
+    assert viewer._viewer._ngl_component_names == []
+
+
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_compute_bonds_in_structure_data_viewer():
     # Check the function to compute bonds.


### PR DESCRIPTION
## Summary

Fix stale bond cylinders remaining in `StructureDataViewer` after the selected structure is cleared.

## Root cause

Bonds are drawn with `nglview._add_shape(...)`, which creates a separate NGL component in addition to the structure component. The previous cleanup removed only `component_0`, so clearing the viewer removed the atoms but left the bond shape component behind.

## Changes

- Update `remove_viewer_components()` to remove every NGL component from the viewer.
- Add a regression test that renders a structure with a bond shape component, clears the structure, and verifies all NGL components are removed.

## Validation

- Direct component check: rendering creates `['Structure', 'nglview.shape.Shape']`; clearing leaves zero components.
- `python -m compileall aiidalab_widgets_base/viewers.py tests/test_viewers.py`
- `python -m ruff check aiidalab_widgets_base/viewers.py tests/test_viewers.py`

A focused local `pytest` run is blocked in this container before reaching these tests because the AiiDA PostgreSQL fixture expects the system `locate` command to find `pg_ctl`.