### PR TITLE
tests: use sqlite-based test fixtures from aiida-core

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,28 @@ import numpy as np
 import pytest
 from aiida import engine, orm, plugins
 
-pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
+# Load aiida-core's sqlite-based pytest fixtures
+pytest_plugins = ["aiida.tools.pytest_fixtures"]
+
+
+@pytest.fixture(scope="session")
+def aiida_profile(aiida_config, aiida_profile_factory, config_sqlite_dos):
+    """Create and load a profile with ``core.sqlite_dos`` as a storage backend and RabbitMQ as the broker.
+
+    This overrides the ``aiida_profile`` fixture provided by ``aiida-core`` which runs with ``core.sqlite_dos`` and
+    without broker. However, tests in this package make use of the daemon which requires a broker.
+    """
+    broker = "core.rabbitmq"
+    storage = "core.sqlite_dos"
+    config = config_sqlite_dos()
+
+    with aiida_profile_factory(
+        aiida_config,
+        storage_backend=storage,
+        storage_config=config,
+        broker_backend=broker,
+    ) as profile:
+        yield profile
 
 
 @pytest.fixture
@@ -270,9 +291,11 @@ def folder_data_object():
 
 
 @pytest.fixture
-def aiida_local_code_bash(aiida_local_code_factory):
-    """Return a `Code` configured for the bash executable."""
-    return aiida_local_code_factory(executable="bash", entry_point="bash")
+def aiida_local_code_bash(aiida_code_installed):
+    """Return `InstalledCode` configured for bash executable."""
+    return aiida_code_installed(
+        filepath_executable="/bin/bash", default_calc_job_plugin="bash"
+    )
 
 
 @pytest.fixture
@@ -339,9 +362,11 @@ def mock_eln_config():
 
 
 @pytest.fixture
-def pw_code(aiida_local_code_factory):
+def pw_code(aiida_code_installed):
     """Return a `Code` configured for the pw.x executable."""
 
-    return aiida_local_code_factory(
-        label="pw", executable="bash", entry_point="quantumespresso.pw"
+    return aiida_code_installed(
+        label="pw",
+        filepath_executable="/bin/bash",
+        default_calc_job_plugin="quantumespresso.pw",
     )


### PR DESCRIPTION
Switch from deprecated `aiida.manage.tests.pytest_fixtures` pytest plugin to `aiida.tools.pytest_fixtures` which are based on SQLite DB backend so we no longer need Postgresql to run the tests. Currently, we still need the RabbitMQ service running though.