### PR TITLE
Run selenium tests on python 3.12 nbclassic image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                docker-tag: [pr-479]
+                docker-tag: [edge]
             fail-fast: false
 
         runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             matrix:
                 browser: [Chrome, Firefox]
                 # test on the latest and the oldest supported version
-                docker-tag: [aiida-2.7.2]
+                docker-tag: [pr-479]
             fail-fast: false
 
         runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR is meant to test the upcoming nbclassic based python 3.12 image which is being prepared in aiidalab/aiidalab-docker-stack#479. Not meant to be merged.

EDIT: 3.12 image now has the `edge` tag so this can be merged.