### PR TITLE
Bump version v3.0.0a0 -> v3.0.0a1

### DIFF
--- a/aiidalab_widgets_base/__init__.py
+++ b/aiidalab_widgets_base/__init__.py
@@ -117,4 +117,4 @@ __all__ = [
     "viewer",
 ]
 
-__version__ = "3.0.0a0"
+__version__ = "3.0.0a1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ docs =
 aiidalab_widgets_base.static.styles = *.css
 
 [bumpver]
-current_version = "v3.0.0a0"
+current_version = "v3.0.0a1"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = True


### PR DESCRIPTION
Let's make another alpha version, there's been a few commits since the last one, but most notably I want the nglview v4 bump, which should resolve the integration test failures in aiidalab/aiidalab-docker-stack#479 (don't ask why, the reason is too annoying to write down here :anguished: )