### PR TITLE
Fix AiidaNodeViewer not resetting when assigned None

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -76,8 +76,15 @@ class AiidaNodeViewWidget(ipw.VBox):
 
     @tl.observe("node")
     def _observe_node(self, change):
-        if not ((node := change["new"]) and node != change["old"]):
+        node = change["new"]
+        if node == change["old"]:
             return
+        if not node:
+            with self._output:
+                clear_output()
+            self.children = []
+            return
+
         if node.uuid in self.node_views:
             self.children = [self.node_views[node.uuid]]
             return

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -361,6 +361,9 @@ def test_node_view_caching():
     node = orm.Int(1)
     node_view.node = node
     viewer = node_view.children[0]
+
     node_view.node = None
+    assert not node_view.children
+
     node_view.node = node
     assert node_view.children[0] is viewer

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -358,12 +358,19 @@ def test_node_view_for_non_widget_viewer():
 def test_node_view_caching():
     """Test that providing a given node a second time returns the cached viewer."""
     node_view = viewers.AiidaNodeViewWidget()
-    node = orm.Int(1)
+    node = orm.Dict()
     node_view.node = node
     viewer = node_view.children[0]
+    assert len(node_view.node_views) == 1
+
+    # orm.Int doesn't have a dedicated viewer
+    # so it will not be cached.
+    node_view.node = orm.Int(2)
+    assert len(node_view.node_views) == 1
 
     node_view.node = None
     assert not node_view.children
 
     node_view.node = node
     assert node_view.children[0] is viewer
+    assert len(node_view.node_views) == 1

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -1,3 +1,5 @@
+import sys
+from io import StringIO
 from pathlib import Path
 
 import ase
@@ -340,8 +342,6 @@ def test_loading_viewer_using_process_type(generate_calc_job_node):
 
 def test_node_view_for_non_widget_viewer():
     """Test that a node with no registered viewer is displayed in an output widget"""
-    import sys
-    from io import StringIO
 
     # Intercepting stdout because `ipw.Output` does not
     # store outputs in non-interactive environments.
@@ -365,7 +365,12 @@ def test_node_view_caching():
 
     # orm.Int doesn't have a dedicated viewer
     # so it will not be cached.
-    node_view.node = orm.Int(2)
+    stdout = sys.stdout
+    with StringIO() as captured:
+        sys.stdout = captured
+        node_view.node = orm.Int(2)
+    sys.stdout = stdout
+
     assert len(node_view.node_views) == 1
 
     node_view.node = None


### PR DESCRIPTION
I noticed this issue when trying to upgrade AtmoSpec to AWB 2.4.0.

Turns out #686 subtly broke the `AiidaNodeViewWidget` is it was not resetting when the `node` traitlet was assigned None. See the added assertion in the unit test which is failing on current master.