### PR TITLE
Simplify ReadTheDocs build config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,21 +4,13 @@
 
 version: 2
 
-# Using uv installer to speed up the build
-# https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
-build:
-    os: ubuntu-22.04
-    tools:
-        python: '3.11'
-    jobs:
-        pre_create_environment:
-            - asdf plugin add uv
-            - asdf install uv 0.7.4
-            - asdf global uv 0.7.4
-        create_environment:
-            - uv venv $READTHEDOCS_VIRTUALENV_PATH
-        install:
-            - uv pip install .[docs] --no-cache --prefix $READTHEDOCS_VIRTUALENV_PATH
+python:
+    install:
+        - method: uv
+          command: pip
+          path: .
+          extras:
+              - docs
 
 sphinx:
     builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,11 @@
 
 version: 2
 
+build:
+    os: ubuntu-24.04
+    tools:
+        python: '3.12'
+
 python:
     install:
         - method: uv


### PR DESCRIPTION
ReadTheDocs now supports uv installer natively, so we can simplify the configuration a little bit, per: 
https://docs.readthedocs.com/platform/stable/config-file/v2.html#uv

EDIT: Looks like this doesn't work as expected, will open a bug report 