### PR TITLE
Add optional NGL viewer axes and default view control

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -1175,7 +1175,11 @@ class _StructureDataBaseViewer(ipw.VBox):
         # RGB ~ XYZ convention; green/blue darkened for contrast on a light background.
         axes = [
             ("x", np.array([length, 0.0, 0.0]), [1.0, 0.0, 0.0]),  # red (R, G, B)
-            ("y", np.array([0.0, length, 0.0]), [0.0, 0.6, 0.0]),  # dark green (R, G, B)
+            (
+                "y",
+                np.array([0.0, length, 0.0]),
+                [0.0, 0.6, 0.0],
+            ),  # dark green (R, G, B)
             ("z", np.array([0.0, 0.0, length]), [0.0, 0.2, 1.0]),  # blue-cyan (R, G, B)
         ]
         shapes = []

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -1134,7 +1134,11 @@ class _StructureDataBaseViewer(ipw.VBox):
         return default_orientation.ravel().tolist()
 
     def set_default_view(self, _=None):
-        """Orient the viewer with x horizontal, y vertical, and z out of screen."""
+        """Orient the viewer with x horizontal, y vertical, and z out of screen.
+
+        If the live camera matrix is not yet available (e.g. nothing rendered),
+        ``_default_view_orientation`` returns None; we then only re-center.
+        """
         orientation = self._default_view_orientation()
         if orientation is not None:
             self._viewer.control.orient(orientation)
@@ -1158,17 +1162,21 @@ class _StructureDataBaseViewer(ipw.VBox):
         positions = self.displayed_structure.get_positions()
         cell_lengths = self.displayed_structure.cell.lengths()
         structure_extent = np.ptp(positions, axis=0) if len(positions) else [0, 0, 0]
-        extent = max(np.max(cell_lengths), np.max(structure_extent), 5.0)
-        length = 0.2 * extent
-        radius = 0.06 * length
-        label_size = 0.35 * length
-        label_offset = 0.12 * length
+        # Axis arrows are sized relative to the structure/cell, with a floor
+        # so axes stay visible for very small molecules.
+        MIN_EXTENT = 5.0  # Å
+        extent = max(np.max(cell_lengths), np.max(structure_extent), MIN_EXTENT)
+        length = 0.2 * extent  # arrow length as a fraction of the extent
+        radius = 0.06 * length  # arrow shaft radius
+        label_size = 0.35 * length  # axis-label text height
+        label_offset = 0.12 * length  # gap between arrow tip and its label
         origin = np.zeros(3)
 
+        # RGB ~ XYZ convention; green/blue darkened for contrast on a light background.
         axes = [
-            ("x", np.array([length, 0.0, 0.0]), [1.0, 0.0, 0.0]),
-            ("y", np.array([0.0, length, 0.0]), [0.0, 0.6, 0.0]),
-            ("z", np.array([0.0, 0.0, length]), [0.0, 0.2, 1.0]),
+            ("x", np.array([length, 0.0, 0.0]), [1.0, 0.0, 0.0]),  # red (R, G, B)
+            ("y", np.array([0.0, length, 0.0]), [0.0, 0.6, 0.0]),  # dark green (R, G, B)
+            ("z", np.array([0.0, 0.0, length]), [0.0, 0.2, 1.0]),  # blue-cyan (R, G, B)
         ]
         shapes = []
         for label, vector, color in axes:

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -319,11 +319,31 @@ class _StructureDataBaseViewer(ipw.VBox):
     DEFAULT_SELECTION_COLOR = "green"
     REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
     DEFAULT_REPRESENTATION = "_aiidalab_viewer_representation_default"
+    DEFAULT_VIEW_ORIENTATION = [
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    ]
     _CELL_LABELS = {
         1: ["length", "Å"],
         2: ["area", "Å²"],
         3: ["volume", "Å³"],
     }
+
+    show_axes = tl.Bool(False)
 
     def __init__(
         self,
@@ -339,6 +359,8 @@ class _StructureDataBaseViewer(ipw.VBox):
         :param default_camera: default camera (orthographic|perspective), can be changed in the Appearance tab.
         """
         # Defining viewer box.
+        self.show_axes = kwargs.pop("show_axes", self.show_axes)
+        self._axes_component = None
 
         # Nglviwer
         self._viewer = nglview.NGLWidget()
@@ -493,7 +515,20 @@ class _StructureDataBaseViewer(ipw.VBox):
         center_button = ipw.Button(description="Center molecule")
         center_button.on_click(lambda _: self._viewer.center())
 
-        # 5. representations buttons
+        # 5. Default orientation button.
+        default_view_button = ipw.Button(description="Default view", icon="refresh")
+        default_view_button.on_click(self.set_default_view)
+
+        # 6. Axes control.
+        show_axes = ipw.Checkbox(
+            description="Show axes",
+            value=self.show_axes,
+            indent=False,
+            style={"description_width": "initial"},
+        )
+        tl.link((show_axes, "value"), (self, "show_axes"))
+
+        # 7. representations buttons
         self.representations_header = ipw.HBox(
             [
                 ipw.HTML(
@@ -574,6 +609,8 @@ class _StructureDataBaseViewer(ipw.VBox):
                 background_color,
                 camera_type,
                 center_button,
+                default_view_button,
+                show_axes,
                 representation_accordion,
             ]
         )
@@ -1079,6 +1116,67 @@ class _StructureDataBaseViewer(ipw.VBox):
         """Remove all components from the viewer."""
         for cid in list(self._viewer._ngl_component_ids):
             self._viewer.remove_component(cid)
+        self._axes_component = None
+
+    def _default_view_orientation(self):
+        """Return a default rotation while preserving the current camera scale."""
+        if len(self._viewer._camera_orientation) != 16:
+            return None
+
+        orientation = np.array(self._viewer._camera_orientation).reshape(4, 4)
+        scale = np.linalg.norm(orientation[0, :3])
+        if scale == 0:
+            return None
+
+        default_orientation = np.array(self.DEFAULT_VIEW_ORIENTATION).reshape(4, 4)
+        default_orientation[:3, :3] *= scale
+        default_orientation[3, :3] = orientation[3, :3]
+        return default_orientation.ravel().tolist()
+
+    def set_default_view(self, _=None):
+        """Orient the viewer with x horizontal, y vertical, and z out of screen."""
+        orientation = self._default_view_orientation()
+        if orientation is not None:
+            self._viewer.control.orient(orientation)
+        self._viewer.center()
+
+    @tl.observe("show_axes")
+    def _observe_show_axes(self, _=None):
+        if isinstance(self.displayed_structure, ase.Atoms):
+            self._update_axes()
+
+    def _remove_axes(self):
+        if getattr(self._axes_component, "id", None) in self._viewer._ngl_component_ids:
+            self._viewer.remove_component(self._axes_component)
+        self._axes_component = None
+
+    def _update_axes(self):
+        self._remove_axes()
+        if not self.show_axes or not isinstance(self.displayed_structure, ase.Atoms):
+            return
+
+        positions = self.displayed_structure.get_positions()
+        cell_lengths = self.displayed_structure.cell.lengths()
+        structure_extent = np.ptp(positions, axis=0) if len(positions) else [0, 0, 0]
+        extent = max(np.max(cell_lengths), np.max(structure_extent), 5.0)
+        length = 0.2 * extent
+        radius = 0.06 * length
+        label_size = 0.35 * length
+        label_offset = 0.12 * length
+        origin = np.zeros(3)
+
+        axes = [
+            ("x", np.array([length, 0.0, 0.0]), [1.0, 0.0, 0.0]),
+            ("y", np.array([0.0, length, 0.0]), [0.0, 0.6, 0.0]),
+            ("z", np.array([0.0, 0.0, length]), [0.0, 0.2, 1.0]),
+        ]
+        shapes = []
+        for label, vector, color in axes:
+            end = origin + vector
+            label_position = end + label_offset * vector / np.linalg.norm(vector)
+            shapes.append(("arrow", origin.tolist(), end.tolist(), color, radius))
+            shapes.append(("text", label_position.tolist(), color, label_size, label))
+        self._axes_component = self._viewer._add_shape(shapes, name="axes")
 
     @tl.default("supercell")
     def _default_supercell(self):
@@ -1323,6 +1421,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
                 self._viewer.set_representations(nglview_params, component=0)
                 self._viewer.add_unitcell()
                 self._viewer._add_shape(set(bonds), name="bonds")
+                self._update_axes()
                 self._viewer.center()
                 # In case of a structure with only one atom, the `center()` method will show a black sphere.
                 if len(self.displayed_structure) == 1:

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -1130,7 +1130,6 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         default_orientation = np.array(self.DEFAULT_VIEW_ORIENTATION).reshape(4, 4)
         default_orientation[:3, :3] *= scale
-        default_orientation[3, :3] = orientation[3, :3]
         return default_orientation.ravel().tolist()
 
     def set_default_view(self, _=None):
@@ -1164,8 +1163,8 @@ class _StructureDataBaseViewer(ipw.VBox):
         structure_extent = np.ptp(positions, axis=0) if len(positions) else [0, 0, 0]
         # Axis arrows are sized relative to the structure/cell, with a floor
         # so axes stay visible for very small molecules.
-        MIN_EXTENT = 5.0  # Å
-        extent = max(np.max(cell_lengths), np.max(structure_extent), MIN_EXTENT)
+        min_extent = 5.0  # Å
+        extent = max(np.max(cell_lengths), np.max(structure_extent), min_extent)
         length = 0.2 * extent  # arrow length as a fraction of the extent
         radius = 0.06 * length  # arrow shaft radius
         label_size = 0.35 * length  # axis-label text height

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -414,6 +414,34 @@ def test_structure_data_viewer_default_view_button():
     )
 
 
+def test_default_view_without_camera_orientation():
+    """With no valid 16-element camera matrix, set_default_view must not emit `orient`."""
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = ase.Atoms("H", positions=[(0.0, 0.0, 0.0)])
+    viewer._viewer._camera_orientation = []  # malformed / unset
+
+    before = len(viewer._viewer._ngl_msg_archive)
+    viewer.set_default_view()
+    messages = viewer._viewer._ngl_msg_archive[before:]
+
+    # With no valid camera matrix, the viewer should not be reoriented at all.
+    assert not any(message.get("methodName") == "orient" for message in messages)
+
+
+def test_show_axes_via_constructor_kwarg():
+    """Axes can be enabled at construction time via the show_axes kwarg."""
+    viewer = viewers.StructureDataViewer(show_axes=True)
+    assert viewer.show_axes is True
+    viewer.structure = ase.Atoms(
+        symbols="H2", positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 0.7)]
+    )
+    assert any(
+        message.get("methodName") == "addShape"
+        and message.get("args", [None])[0] == "axes"
+        for message in viewer._viewer._ngl_msg_archive
+    )
+
+
 def test_structure_data_viewer_axes_are_optional():
     viewer = viewers.StructureDataViewer()
     viewer.structure = ase.Atoms(

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -357,6 +357,108 @@ def test_compute_bonds_in_structure_data_viewer():
     assert len(bonds) == 4
 
 
+def test_structure_data_viewer_default_view_button():
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = ase.Atoms("H", positions=[(0.0, 0.0, 0.0)])
+    viewer._viewer._camera_orientation = [
+        0.0,
+        12.0,
+        0.0,
+        0.0,
+        -12.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        12.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        1.0,
+    ]
+
+    before = len(viewer._viewer._ngl_msg_archive)
+    viewer.set_default_view()
+    messages = viewer._viewer._ngl_msg_archive[before:]
+
+    expected_orientation = [
+        -12.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        12.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -12.0,
+        0.0,
+        1.0,
+        2.0,
+        3.0,
+        1.0,
+    ]
+    assert any(
+        message.get("methodName") == "orient"
+        and message.get("args") == (expected_orientation,)
+        for message in messages
+    )
+
+    appearance_tab = viewer.configuration_box.children[1]
+    assert any(
+        getattr(child, "description", None) == "Default view"
+        for child in appearance_tab.children
+    )
+
+
+def test_structure_data_viewer_axes_are_optional():
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = ase.Atoms(
+        symbols="H2",
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 0.7)],
+        cell=[3.0, 3.0, 3.0],
+        pbc=True,
+    )
+
+    assert viewer.show_axes is False
+    assert not any(
+        message.get("methodName") == "addShape"
+        and message.get("args", [None])[0] == "axes"
+        for message in viewer._viewer._ngl_msg_archive
+    )
+
+    viewer.show_axes = True
+    axes_messages = [
+        message
+        for message in viewer._viewer._ngl_msg_archive
+        if message.get("methodName") == "addShape"
+        and message.get("args", [None])[0] == "axes"
+    ]
+    assert axes_messages
+    axes_shapes = axes_messages[-1]["args"][1]
+    assert [shape[-1] for shape in axes_shapes if shape[0] == "text"] == [
+        "x",
+        "y",
+        "z",
+    ]
+
+    viewer.show_axes = False
+    assert viewer._axes_component is None
+    assert "axes" not in viewer._viewer._ngl_component_names
+
+    appearance_tab = viewer.configuration_box.children[1]
+    axes_controls = [
+        child
+        for child in appearance_tab.children
+        if getattr(child, "description", None) == "Show axes"
+    ]
+    assert len(axes_controls) == 1
+    assert axes_controls[0].value is False
+
+
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_loading_viewer_using_process_type(generate_calc_job_node):
     """Test loading a viewer widget based on the process type of the process node."""

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -396,9 +396,9 @@ def test_structure_data_viewer_default_view_button():
         0.0,
         -12.0,
         0.0,
-        1.0,
-        2.0,
-        3.0,
+        0.0,
+        0.0,
+        0.0,
         1.0,
     ]
     assert any(


### PR DESCRIPTION
This is a narrow replacement for the abandoned #745.

## Scope
- Adds an optional `Show axes` checkbox to the structure viewer appearance tab. It is off by default.
- Adds a `Default view` button that resets the NGL view orientation using `NGLWidget.control.orient`, without inline JavaScript.
- Keeps the change limited to axes/default orientation; zoom and pan controls from #745 are intentionally not included.

## Notes
- `setup.cfg` already allows `nglview>=3.0.8,<5`, so nglview 4 remains within the supported range.

## Tests
- With `nglview 3.0.8`: `python -m pytest tests/test_viewers.py`
- With `nglview 4.0.1`: `python -m pytest tests/test_viewers.py`
- Focused tests also run: `python -m pytest tests/test_viewers.py::test_structure_data_viewer_default_view_button tests/test_viewers.py::test_structure_data_viewer_axes_are_optional`

Ruff was not available in the local environment (`No module named ruff`), but `git diff --check` passes.

## Assistance
Implemented and iterated with Codex.