### PR TITLE
Center SMILES molecules after adding auxiliary cell

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -796,7 +796,6 @@ class SmilesWidget(ipw.VBox):
     def _make_ase(self, species, positions, smiles):
         """Create ase Atoms object."""
         atoms = ase.Atoms(species, positions=positions, pbc=False)
-        atoms.center()
         # We're attaching this info so that it
         # can be later stored as an extra on AiiDA Structure node.
         atoms.info["smiles"] = smiles
@@ -838,6 +837,7 @@ class SmilesWidget(ipw.VBox):
         ase_mol = self._make_ase(species, positions, smiles)
         if self.add_auxiliary_cell:
             ase_mol.cell = np.ptp(ase_mol.positions, axis=0) + 10
+            ase_mol.center()
         return ase_mol
 
     def _mol_from_smiles(self, smiles, steps=1000):

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -292,6 +292,10 @@ def test_smiles_widget():
     cell = widget.structure.cell
     assert all(np.greater(np.diag(cell), [10, 10, 10]))
     assert np.array_equal(cell.angles(), [90.0, 90.0, 90.0])
+    molecule_center = (
+        widget.structure.positions.min(axis=0) + widget.structure.positions.max(axis=0)
+    ) / 2
+    assert np.allclose(molecule_center, np.diag(cell) / 2)
 
     # Regression test that we can generate 1-atom and 2-atom molecules
     widget.smiles.value = "[O]"
@@ -325,6 +329,18 @@ def test_smiles_widget_without_cell():
     assert not any(widget.structure.pbc)
     assert not np.any(widget.structure.cell)
     assert not widget.structure.cell.volume
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_smiles_widget_make_ase_preserves_positions():
+    """Test that raw SMILES coordinates are not centered before adding a cell."""
+    widget = awb.SmilesWidget(add_auxiliary_cell=False)
+    positions = np.array([[10.0, 0.0, 0.0], [11.0, 0.0, 0.0]])
+
+    atoms = widget._make_ase(["H", "H"], positions, "[H][H]")
+
+    assert np.allclose(atoms.positions, positions)
+    assert not np.any(atoms.cell)
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")


### PR DESCRIPTION
## Summary

This PR restores the intended SMILES import behavior around auxiliary cells:

- when `add_auxiliary_cell=True` (the default), the auxiliary cell is added first and the generated molecule is centered inside it;
- when `add_auxiliary_cell=False`, no auxiliary cell is added and the RDKit coordinates are left untouched.

## Root cause

PR #592 moved the auxiliary-cell creation out of `_make_ase()`, but `_make_ase()` still called `atoms.center()` before any real cell was available. As a result, the molecule was centered in ASE's zero/default cell and then the auxiliary cell was added afterward, leaving the molecule near the cell corner.

## Validation

- `python -m pytest tests/test_structures.py::test_smiles_widget tests/test_structures.py::test_smiles_widget_without_cell tests/test_structures.py::test_smiles_widget_make_ase_preserves_positions`
- `python -m pytest tests/test_structures.py`

Implemented with Codex.
