### PR TITLE
PR-R3: Persist viewer representations in extras

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -19,6 +19,7 @@ from .utils import StatusHTML, exceptions, get_ase_from_file, get_formula
 from .viewers import (
     StructureDataViewer,
     restore_viewer_representations_from_extras,
+    store_viewer_representations_in_extras,
 )
 
 CifData = plugins.DataFactory("core.cif")
@@ -88,25 +89,35 @@ class StructureManagerWidget(ipw.VBox):
             self.viewer = StructureDataViewer()
         tl.dlink((self, "structure"), (self.viewer, "structure"))
 
-        # Store button.
+        # Store buttons.
         self.btn_store = ipw.Button(description="Store in AiiDA", disabled=True)
         self.btn_store.on_click(self.store_structure)
+        self.btn_store_representations = ipw.Button(
+            description="Store representations", disabled=True
+        )
+        self.btn_store_representations.on_click(self.store_representations)
 
         # Label and description that are stored along with the new structure.
         self.structure_label = ipw.Text(description="Label")
         self.structure_description = ipw.Text(description="Description")
 
         # Store format selector.
+        default_node_class = node_class or "StructureData"
         data_format = ipw.RadioButtons(
             options=tuple(
                 (key, value) for key, value in self.SUPPORTED_DATA_FORMATS.items()
+            ),
+            value=self.SUPPORTED_DATA_FORMATS.get(
+                default_node_class, self.SUPPORTED_DATA_FORMATS["StructureData"]
             ),
             description="Data type:",
         )
         tl.link((data_format, "label"), (self, "node_class"))
 
-        # Store button, store class selector, description.
-        store_and_description = [self.btn_store] if storable else []
+        # Store buttons, store class selector, description.
+        store_and_description = (
+            [self.btn_store, self.btn_store_representations] if storable else []
+        )
 
         if node_class is None:
             store_and_description.append(data_format)
@@ -213,6 +224,16 @@ class StructureManagerWidget(ipw.VBox):
 
         return [editors_tab]
 
+    def store_representations(self, _=None):
+        """Store only viewer representations in AiiDA node extras."""
+        if self.structure_node is None or not self.structure_node.is_stored:
+            return
+        self.viewer._apply_representations()
+        store_viewer_representations_in_extras(self.structure_node, self.structure)
+        self.output.value = (
+            f"Viewer representations updated in AiiDA [{self.structure_node}]."
+        )
+
     def store_structure(self, _=None):
         """Stores the structure in AiiDA database."""
 
@@ -224,6 +245,8 @@ class StructureManagerWidget(ipw.VBox):
             )
             return
         self.btn_store.disabled = True
+        self.btn_store_representations.disabled = False
+        store_viewer_representations_in_extras(self.structure_node, self.structure)
         self.structure_node.label = self.structure_label.value
         self.structure_label.disabled = True
         self.structure_node.description = self.structure_description.value
@@ -289,6 +312,7 @@ class StructureManagerWidget(ipw.VBox):
             structure_node = structure_node_type(ase=structure)
             if "smiles" in structure.info:
                 structure_node.base.extras.set("smiles", structure.info["smiles"])
+            store_viewer_representations_in_extras(structure_node, structure)
             return structure_node
 
         # If the input_structure trait is set to AiiDA node, check what type
@@ -298,14 +322,19 @@ class StructureManagerWidget(ipw.VBox):
                 return structure
 
         # Using self.structure, as it was already converted to the ASE Atoms object.
-        return structure_node_type(ase=self.structure)
+        structure_node = structure_node_type(ase=self.structure)
+        store_viewer_representations_in_extras(structure_node, self.structure)
+        return structure_node
 
     @tl.observe("structure_node")
     def _observe_structure_node(self, change):
         """Modify structure label and description when a new structure is provided."""
         struct = change["new"]
+        if hasattr(self.viewer, "_structure_node"):
+            self.viewer._structure_node = struct
         if struct is None:
             self.btn_store.disabled = True
+            self.btn_store_representations.disabled = True
             self.structure_label.value = ""
             self.structure_label.disabled = True
             self.structure_description.value = ""
@@ -313,12 +342,14 @@ class StructureManagerWidget(ipw.VBox):
             return
         if struct.is_stored:
             self.btn_store.disabled = True
+            self.btn_store_representations.disabled = False
             self.structure_label.value = struct.label
             self.structure_label.disabled = True
             self.structure_description.value = struct.description
             self.structure_description.disabled = True
         else:
             self.btn_store.disabled = False
+            self.btn_store_representations.disabled = True
             self.structure_label.value = self.structure.get_chemical_formula()
             self.structure_label.disabled = False
             self.structure_description.value = ""

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -16,7 +16,10 @@ from aiida import common, engine, orm, plugins
 # Local imports
 from .data import FunctionalGroupSelectorWidget
 from .utils import StatusHTML, exceptions, get_ase_from_file, get_formula
-from .viewers import StructureDataViewer
+from .viewers import (
+    StructureDataViewer,
+    restore_viewer_representations_from_extras,
+)
 
 CifData = plugins.DataFactory("core.cif")
 StructureData = plugins.DataFactory("core.structure")
@@ -336,11 +339,16 @@ class StructureManagerWidget(ipw.VBox):
             change["new"], CifData
         ):  # Special treatement of the CifData object
             str_io = io.StringIO(change["new"].get_content())
-            self.structure = ase.io.read(
+            structure = ase.io.read(
                 str_io, format="cif", reader="ase", store_tags=True
             )
+            self.structure = restore_viewer_representations_from_extras(
+                change["new"], structure
+            )
         elif isinstance(change["new"], StructureData):
-            self.structure = change["new"].get_ase()
+            self.structure = restore_viewer_representations_from_extras(
+                change["new"], change["new"].get_ase()
+            )
 
         else:
             self.structure = None

--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -339,9 +339,7 @@ class StructureManagerWidget(ipw.VBox):
             change["new"], CifData
         ):  # Special treatement of the CifData object
             str_io = io.StringIO(change["new"].get_content())
-            structure = ase.io.read(
-                str_io, format="cif", reader="ase", store_tags=True
-            )
+            structure = ase.io.read(str_io, format="cif", reader="ase", store_tags=True)
             self.structure = restore_viewer_representations_from_extras(
                 change["new"], structure
             )

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -167,6 +167,81 @@ class DictViewer(ipw.VBox):
         super().__init__([self.widget], **kwargs)
 
 
+REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
+DEFAULT_REPRESENTATION = f"{REPRESENTATION_PREFIX}default"
+_REPRESENTATION_TYPE_TO_TOKEN = {
+    "ball+stick": "ballstick",
+    "spacefill": "spacefill",
+}
+_REPRESENTATION_TOKEN_TO_TYPE = {
+    token: representation_type
+    for representation_type, token in _REPRESENTATION_TYPE_TO_TOKEN.items()
+}
+_REPRESENTATION_STYLE_PATTERN = re.compile(
+    rf"^{REPRESENTATION_PREFIX}"
+    r"(?P<representation_type>ballstick|spacefill)_"
+    r"r(?P<size>[0-9mp]+)_"
+    r"(?P<color>[A-Za-z0-9]+)_"
+    r"(?P<token>[A-Za-z0-9]+)$"
+)
+
+
+def _encode_representation_size(size):
+    """Encode a representation size as an extxyz-safe token."""
+    return f"{float(size):g}".replace("-", "m").replace(".", "p")
+
+
+def _decode_representation_size(size):
+    """Decode a representation size token."""
+    return float(size.replace("m", "-").replace("p", "."))
+
+
+def _safe_representation_token(token, fallback="style"):
+    """Return a compact extxyz-safe token for a representation style id."""
+    token = re.sub(r"[^A-Za-z0-9]", "", str(token))
+    return token or fallback
+
+
+def encode_representation_style_id(
+    prefix=REPRESENTATION_PREFIX,
+    *,
+    representation_type="ball+stick",
+    size=3,
+    color="element",
+    token=None,
+):
+    """Build an extxyz-safe representation array name with style metadata."""
+    representation_token = _REPRESENTATION_TYPE_TO_TOKEN.get(
+        representation_type, "ballstick"
+    )
+    size_token = _encode_representation_size(size)
+    color_token = _safe_representation_token(color, fallback="element")
+    unique_token = _safe_representation_token(
+        token if token is not None else shortuuid.uuid(), fallback=shortuuid.uuid()
+    )
+    return f"{prefix}{representation_token}_r{size_token}_{color_token}_{unique_token}"
+
+
+def parse_representation_style_id(style_id):
+    """Parse style metadata encoded in a representation array name.
+
+    Old opaque representation ids intentionally return ``None`` so they keep the
+    historical default display settings.
+    """
+    match = _REPRESENTATION_STYLE_PATTERN.match(style_id)
+    if match is None:
+        return None
+    representation_type = _REPRESENTATION_TOKEN_TO_TYPE[
+        match.group("representation_type")
+    ]
+    return {
+        "representation_type": representation_type,
+        "size": _decode_representation_size(match.group("size")),
+        "color": match.group("color"),
+        "token": match.group("token"),
+    }
+
+
 class NglViewerRepresentation(ipw.HBox):
     """This class represents the parameters for displaying a structure in NGLViewer.
 
@@ -191,6 +266,13 @@ class NglViewerRepresentation(ipw.HBox):
 
         self.atom_show_threshold = atom_show_threshold
         self.style_id = style_id
+        style_metadata = parse_representation_style_id(style_id)
+        self._style_token = (
+            style_metadata["token"] if style_metadata is not None else shortuuid.uuid()
+        )
+        self._sync_style_id_with_settings = (
+            style_id != DEFAULT_REPRESENTATION and style_metadata is not None
+        )
 
         self.show = ipw.Checkbox(
             value=True,
@@ -223,6 +305,11 @@ class NglViewerRepresentation(ipw.HBox):
             layout={"width": "80px"},
             style={"description_width": "initial"},
         )
+        if style_metadata is not None:
+            self.type.value = style_metadata["representation_type"]
+            self.size.value = style_metadata["size"]
+            if style_metadata["color"] in self.color.options:
+                self.color.value = style_metadata["color"]
 
         # Delete button.
         self.delete_button = ipw.Button(
@@ -258,9 +345,28 @@ class NglViewerRepresentation(ipw.HBox):
                     np.where(self.atoms_in_representation(structure))[0], shift=1
                 )
 
+    def _refresh_style_id_from_widget_values(self, structure: ase.Atoms | None):
+        """Keep encoded style ids aligned with the current representation widgets."""
+        if not self._sync_style_id_with_settings or self.viewer_class is None:
+            return
+        new_style_id = encode_representation_style_id(
+            self.viewer_class.REPRESENTATION_PREFIX,
+            representation_type=self.type.value,
+            size=self.size.value,
+            color=self.color.value,
+            token=self._style_token,
+        )
+        if new_style_id == self.style_id:
+            return
+        old_style_id = self.style_id
+        self.style_id = new_style_id
+        if structure and old_style_id in structure.arrays:
+            del structure.arrays[old_style_id]
+
     def add_myself_to_atoms_object(self, structure: ase.Atoms | None):
         """Add representation array to the structure object. If the array already exists, update it."""
         if structure:
+            self._refresh_style_id_from_widget_values(structure)
             array_representation = np.full(len(structure), -1, dtype=int)
             selection = np.array(
                 string_range_to_list(self.selection.value, shift=-1)[0], dtype=int
@@ -317,8 +423,8 @@ class _StructureDataBaseViewer(ipw.VBox):
     DEFAULT_SELECTION_OPACITY = 0.2
     DEFAULT_SELECTION_RADIUS = 6
     DEFAULT_SELECTION_COLOR = "green"
-    REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
-    DEFAULT_REPRESENTATION = "_aiidalab_viewer_representation_default"
+    REPRESENTATION_PREFIX = REPRESENTATION_PREFIX
+    DEFAULT_REPRESENTATION = DEFAULT_REPRESENTATION
     _CELL_LABELS = {
         1: ["length", "Å"],
         2: ["area", "Å²"],
@@ -583,7 +689,8 @@ class _StructureDataBaseViewer(ipw.VBox):
         self._all_representations = [
             *self._all_representations,
             NglViewerRepresentation(
-                style_id=style_id or f"{self.REPRESENTATION_PREFIX}{shortuuid.uuid()}",
+                style_id=style_id
+                or encode_representation_style_id(self.REPRESENTATION_PREFIX),
                 indices=indices,
             ),
         ]

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -169,6 +169,7 @@ class DictViewer(ipw.VBox):
 
 REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
 DEFAULT_REPRESENTATION = f"{REPRESENTATION_PREFIX}default"
+VIEWER_REPRESENTATIONS_EXTRA = "aiidalab_viewer_representations"
 _REPRESENTATION_TYPE_TO_TOKEN = {
     "ball+stick": "ballstick",
     "spacefill": "spacefill",
@@ -240,6 +241,23 @@ def parse_representation_style_id(style_id):
         "color": match.group("color"),
         "token": match.group("token"),
     }
+
+
+def restore_viewer_representations_from_extras(node, structure):
+    """Restore viewer representation masks from AiiDA node extras into ASE arrays."""
+    if node is None or structure is None:
+        return structure
+    representations = node.base.extras.get(VIEWER_REPRESENTATIONS_EXTRA, {})
+    if not isinstance(representations, dict):
+        return structure
+    for key, values in representations.items():
+        if not str(key).startswith(REPRESENTATION_PREFIX):
+            continue
+        values = np.asarray(values, dtype=int)
+        if len(values) != len(structure):
+            continue
+        structure.set_array(key, values)
+    return structure
 
 
 class NglViewerRepresentation(ipw.HBox):
@@ -1346,7 +1364,9 @@ class StructureDataViewer(_StructureDataBaseViewer):
             self.pk = None
         elif isinstance(structure, (orm.StructureData, orm.CifData)):
             self.pk = structure.pk
-            structure = structure.get_ase()
+            structure = restore_viewer_representations_from_extras(
+                structure, structure.get_ase()
+            )
 
         # Add default representation array if it is not present.
         # This will make sure that the new structure is displayed at the beginning.
@@ -1389,11 +1409,13 @@ class StructureDataViewer(_StructureDataBaseViewer):
                     indices=np.where(structure.arrays[style_id] >= 1)[0],
                     apply=False,
                 )
-        # Empty atoms selection for the representations that are not present in the structure.
-        # Typically this happens when a new structure is imported.
-        for i, style_id in enumerate(representation_ids):
-            if style_id not in structure_ids:
-                self._all_representations[i].selection.value = ""
+        # Drop representations that are not present in the new structure.
+        # Typically this happens when a different structure is imported/selected.
+        self._all_representations = [
+            representation
+            for representation in self._all_representations
+            if representation.style_id in structure_ids
+        ]
 
         self._observe_supercell()  # To trigger an update of the displayed structure
         self.set_trait("cell", structure.cell)

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -243,6 +243,26 @@ def parse_representation_style_id(style_id):
     }
 
 
+def viewer_representation_arrays_to_dict(structure):
+    """Return viewer representation arrays as JSON-serializable masks."""
+    if structure is None:
+        return {}
+    return {
+        key: np.asarray(value, dtype=int).tolist()
+        for key, value in structure.arrays.items()
+        if key.startswith(REPRESENTATION_PREFIX)
+    }
+
+
+def store_viewer_representations_in_extras(node, structure):
+    """Store viewer representation masks in mutable AiiDA node extras."""
+    if node is None or structure is None:
+        return
+    representations = viewer_representation_arrays_to_dict(structure)
+    if representations:
+        node.base.extras.set(VIEWER_REPRESENTATIONS_EXTRA, representations)
+
+
 def restore_viewer_representations_from_extras(node, structure):
     """Restore viewer representation masks from AiiDA node extras into ASE arrays."""
     if node is None or structure is None:
@@ -825,6 +845,7 @@ class _StructureDataBaseViewer(ipw.VBox):
                 and array not in representation_ids
             ):
                 del self.structure.arrays[array]
+        store_viewer_representations_in_extras(self._structure_node, self.structure)
         self._observe_structure({"new": self.structure})
         self._check_missing_atoms_in_representations()
 
@@ -1334,6 +1355,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
 
     def __init__(self, structure=None, **kwargs):
         super().__init__(**kwargs)
+        self._structure_node = None
         self.add_class("structure-viewer")
         self.structure = structure
 
@@ -1362,8 +1384,10 @@ class StructureDataViewer(_StructureDataBaseViewer):
         structure = change["value"]
         if isinstance(structure, ase.Atoms):
             self.pk = None
+            self._structure_node = None
         elif isinstance(structure, (orm.StructureData, orm.CifData)):
             self.pk = structure.pk
+            self._structure_node = structure
             structure = restore_viewer_representations_from_extras(
                 structure, structure.get_ase()
             )

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -693,7 +693,7 @@ class _StructureDataBaseViewer(ipw.VBox):
             representation_ids.append(representation.style_id)
 
         # Remove missing representations from the structure.
-        for array in self.structure.arrays:
+        for array in list(self.structure.arrays):
             if (
                 array.startswith(self.REPRESENTATION_PREFIX)
                 and array not in representation_ids
@@ -1278,7 +1278,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
             except ValueError:
                 self._add_representation(
                     style_id=style_id,
-                    indices=np.where(structure.arrays[self.style_id] >= 1)[0],
+                    indices=np.where(structure.arrays[style_id] >= 1)[0],
                 )
         # Empty atoms selection for the representations that are not present in the structure.
         # Typically this happens when a new structure is imported.

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -684,7 +684,7 @@ class _StructureDataBaseViewer(ipw.VBox):
             ]
         )
 
-    def _add_representation(self, _=None, style_id=None, indices=None):
+    def _add_representation(self, _=None, style_id=None, indices=None, apply=True):
         """Add a representation to the list of representations."""
         self._all_representations = [
             *self._all_representations,
@@ -694,7 +694,8 @@ class _StructureDataBaseViewer(ipw.VBox):
                 indices=indices,
             ),
         ]
-        self._apply_representations()
+        if apply:
+            self._apply_representations()
 
     def delete_representation(self, representation: NglViewerRepresentation):
         try:
@@ -1386,6 +1387,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
                 self._add_representation(
                     style_id=style_id,
                     indices=np.where(structure.arrays[style_id] >= 1)[0],
+                    apply=False,
                 )
         # Empty atoms selection for the representations that are not present in the structure.
         # Typically this happens when a new structure is imported.

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -8,6 +8,7 @@ from aiida import common, orm
 
 import aiidalab_widgets_base as awb
 import aiidalab_widgets_base.structures as structures
+from aiidalab_widgets_base import viewers
 
 
 @pytest.fixture
@@ -133,6 +134,34 @@ def test_structure_manager_widget(structure_data_object):
     )
     structure_manager_widget.undo()  # Undo the structure creation.
     assert structure_manager_widget.structure is None
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_widget_restores_viewer_representations_from_extras():
+    style_id = viewers.encode_representation_style_id(
+        viewers.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=2,
+        color="red",
+        token="stored",
+    )
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    node = orm.StructureData(ase=structure).store()
+    node.base.extras.set(viewers.VIEWER_REPRESENTATIONS_EXTRA, {style_id: [1, -1]})
+
+    structure_manager_widget = awb.StructureManagerWidget(
+        importers=[], input_structure=node
+    )
+
+    representation_ids = [
+        rep.style_id for rep in structure_manager_widget.viewer._all_representations
+    ]
+    assert style_id in representation_ids
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -137,6 +137,72 @@ def test_structure_manager_widget(structure_data_object):
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_widget_stores_viewer_representations_in_extras():
+    style_id = viewers.encode_representation_style_id(
+        viewers.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=2,
+        color="red",
+        token="stored",
+    )
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    structure.set_array(style_id, np.array([1, -1], dtype=int))
+    structure_manager_widget = awb.StructureManagerWidget(
+        importers=[], input_structure=structure
+    )
+
+    structure_manager_widget.btn_store.click()
+    stored = structure_manager_widget.structure_node
+
+    assert stored.base.extras.get(viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
+        viewers.DEFAULT_REPRESENTATION: [0, 0],
+        style_id: [1, -1],
+    }
+
+    reloaded_widget = awb.StructureManagerWidget(importers=[], input_structure=stored)
+    representation_ids = [
+        rep.style_id for rep in reloaded_widget.viewer._all_representations
+    ]
+    assert style_id in representation_ids
+    representation = reloaded_widget.viewer._all_representations[
+        representation_ids.index(style_id)
+    ]
+    assert representation.selection.value == "1"
+    assert representation.type.value == "spacefill"
+    assert representation.size.value == 2
+    assert representation.color.value == "red"
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_widget_updates_stored_representations_extra():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+        cell=[5.0, 5.0, 5.0],
+        pbc=True,
+    )
+    node = orm.StructureData(ase=structure).store()
+    structure_manager_widget = awb.StructureManagerWidget(
+        importers=[], input_structure=node
+    )
+
+    assert structure_manager_widget.btn_store.disabled is True
+    assert structure_manager_widget.btn_store_representations.disabled is False
+
+    structure_manager_widget.viewer._all_representations[0].selection.value = "1"
+    structure_manager_widget.btn_store_representations.click()
+
+    assert node.base.extras.get(viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
+        viewers.DEFAULT_REPRESENTATION: [1, -1]
+    }
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_manager_widget_restores_viewer_representations_from_extras():
     style_id = viewers.encode_representation_style_id(
         viewers.REPRESENTATION_PREFIX,

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -5,6 +5,7 @@ from io import StringIO
 from pathlib import Path
 
 import ase
+import numpy as np
 import pytest
 import traitlets as tl
 from aiida import orm
@@ -318,6 +319,23 @@ def test_structure_data_viewer_representation(structure_data_object):
 
     with pytest.raises(tl.TraitError):
         v.structure = orm.Int(1)
+
+
+def test_structure_data_viewer_imports_unknown_representation_array():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    style_id = f"{viewers.StructureDataViewer.REPRESENTATION_PREFIX}custom"
+    structure.set_array(style_id, np.array([1, -1], dtype=int))
+
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = structure
+
+    representation_ids = [rep.style_id for rep in viewer._all_representations]
+    assert style_id in representation_ids
+    representation = viewer._all_representations[representation_ids.index(style_id)]
+    assert representation.selection.value == "1"
 
 
 def test_structure_data_viewer_clears_bond_shape_components():

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -367,6 +367,45 @@ def test_structure_data_viewer_imports_encoded_representation_array():
     assert representation.color.value == "red"
 
 
+def test_structure_data_viewer_imports_multiple_encoded_representation_arrays():
+    structure = ase.Atoms(
+        symbols=["C", "H", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1), (0.0, 1.0, 0.0)],
+    )
+    style_id_1 = viewers.encode_representation_style_id(
+        viewers.StructureDataViewer.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=2,
+        color="element",
+        token="surface",
+    )
+    style_id_2 = viewers.encode_representation_style_id(
+        viewers.StructureDataViewer.REPRESENTATION_PREFIX,
+        representation_type="ball+stick",
+        size=4,
+        color="red",
+        token="molecule",
+    )
+    structure.set_array(style_id_1, np.array([1, -1, -1], dtype=int))
+    structure.set_array(style_id_2, np.array([-1, 1, 1], dtype=int))
+
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = structure
+
+    representation_ids = [rep.style_id for rep in viewer._all_representations]
+    assert style_id_1 in representation_ids
+    assert style_id_2 in representation_ids
+    representation_1 = viewer._all_representations[representation_ids.index(style_id_1)]
+    representation_2 = viewer._all_representations[representation_ids.index(style_id_2)]
+    assert representation_1.selection.value == "1"
+    assert representation_1.type.value == "spacefill"
+    assert representation_1.size.value == 2
+    assert representation_2.selection.value == "2..3"
+    assert representation_2.type.value == "ball+stick"
+    assert representation_2.size.value == 4
+    assert representation_2.color.value == "red"
+
+
 def test_structure_data_viewer_updates_encoded_representation_array_name():
     structure = ase.Atoms(
         symbols=["C", "H"],

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -367,6 +367,33 @@ def test_structure_data_viewer_imports_encoded_representation_array():
     assert representation.color.value == "red"
 
 
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_data_viewer_restores_representation_arrays_from_extras():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    style_id = viewers.encode_representation_style_id(
+        viewers.StructureDataViewer.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=2,
+        color="red",
+        token="stored",
+    )
+    node = orm.StructureData(ase=structure)
+    node.base.extras.set(viewers.VIEWER_REPRESENTATIONS_EXTRA, {style_id: [1, -1]})
+
+    viewer = viewers.StructureDataViewer(node)
+
+    representation_ids = [rep.style_id for rep in viewer._all_representations]
+    assert style_id in representation_ids
+    representation = viewer._all_representations[representation_ids.index(style_id)]
+    assert representation.selection.value == "1"
+    assert representation.type.value == "spacefill"
+    assert representation.size.value == 2
+    assert representation.color.value == "red"
+
+
 def test_structure_data_viewer_imports_multiple_encoded_representation_arrays():
     structure = ase.Atoms(
         symbols=["C", "H", "H"],
@@ -404,6 +431,34 @@ def test_structure_data_viewer_imports_multiple_encoded_representation_arrays():
     assert representation_2.type.value == "ball+stick"
     assert representation_2.size.value == 4
     assert representation_2.color.value == "red"
+
+
+def test_structure_data_viewer_drops_stale_representations_on_structure_change():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    style_id = viewers.encode_representation_style_id(
+        viewers.StructureDataViewer.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=2,
+        color="red",
+        token="old",
+    )
+    structure.set_array(style_id, np.array([1, -1], dtype=int))
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = structure
+    assert style_id in [rep.style_id for rep in viewer._all_representations]
+
+    viewer.structure = ase.Atoms(
+        symbols=["C", "H", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1), (0.0, 1.0, 0.0)],
+    )
+
+    assert [rep.style_id for rep in viewer._all_representations] == [
+        viewers.DEFAULT_REPRESENTATION
+    ]
+    assert viewer._all_representations[0].selection.value == "1..3"
 
 
 def test_structure_data_viewer_updates_encoded_representation_array_name():

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -336,6 +336,61 @@ def test_structure_data_viewer_imports_unknown_representation_array():
     assert style_id in representation_ids
     representation = viewer._all_representations[representation_ids.index(style_id)]
     assert representation.selection.value == "1"
+    assert representation.type.value == "ball+stick"
+    assert representation.size.value == 3
+    assert representation.color.value == "element"
+
+
+def test_structure_data_viewer_imports_encoded_representation_array():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    style_id = viewers.encode_representation_style_id(
+        viewers.StructureDataViewer.REPRESENTATION_PREFIX,
+        representation_type="spacefill",
+        size=4,
+        color="red",
+        token="surface",
+    )
+    structure.set_array(style_id, np.array([1, -1], dtype=int))
+
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = structure
+
+    representation_ids = [rep.style_id for rep in viewer._all_representations]
+    assert style_id in representation_ids
+    representation = viewer._all_representations[representation_ids.index(style_id)]
+    assert representation.selection.value == "1"
+    assert representation.type.value == "spacefill"
+    assert representation.size.value == 4
+    assert representation.color.value == "red"
+
+
+def test_structure_data_viewer_updates_encoded_representation_array_name():
+    structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = structure
+
+    viewer._add_representation()
+    representation = viewer._all_representations[-1]
+    old_style_id = representation.style_id
+    representation.selection.value = "2"
+    representation.type.value = "spacefill"
+    representation.size.value = 4
+    representation.color.value = "red"
+
+    viewer._apply_representations()
+
+    assert old_style_id not in viewer.structure.arrays
+    assert representation.style_id in viewer.structure.arrays
+    assert representation.style_id.startswith(
+        f"{viewer.REPRESENTATION_PREFIX}spacefill_r4_red_"
+    )
+    assert viewer.structure.arrays[representation.style_id].tolist() == [-1, 1]
 
 
 def test_structure_data_viewer_clears_bond_shape_components():


### PR DESCRIPTION
## What

PR-R3 in the representation split. This is stacked on top of #769.

This PR adds the persistence side of viewer representations:

- convert viewer representation arrays into JSON-safe masks;
- store those masks in `StructureData`/`CifData` extras;
- add a `Store representations` button for already-stored structures;
- make `Store in AiiDA` persist representation masks when a structure is first stored;
- keep standalone viewer `Apply representations` in sync with extras when the viewer has a stored node.

## Why

Users can now change visualization styles without creating a new structure node. The geometry remains the same AiiDA node, while the mutable viewer state lives in extras.

## Small defaulting fix

This PR also makes the `StructureManagerWidget` storage format selector explicitly default to `StructureData` when no `node_class` is passed.

Previously the `RadioButtons` widget relied on the first entry in `SUPPORTED_DATA_FORMATS`. That is implicit and can silently select the wrong storage type if the option order changes. The new logic keeps explicit caller choices unchanged, but falls back to `StructureData` for the default structure-manager path. This matters here because representation persistence is stored on the AiiDA node extras, so the node type must be the one the widget is actually intended to create.

## Chain

- PR-R1: #768, encoded representation style IDs
- PR-R2: #769, load representation masks from extras and drop stale rows
- PR-R3: this PR, persist representation masks back to extras

Implemented with Codex.

## Validation

```bash
python -m pytest tests/test_viewers.py tests/test_structures.py
```

Result: 37 passed, 24 warnings.
