### PR TITLE
Remove failing CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,9 +88,12 @@ jobs:
         strategy:
             matrix:
                 python-version: ['3.9', '3.12']
-                # Test latest and oldest supported package versions
-                uv-resolution: ['lowest-direct', 'highest']
-            fail-fast: false
+                uv-resolution: ['highest']
+                include:
+                  # Make sure lowest-support package versions work
+                  # https://docs.astral.sh/uv/concepts/resolution/#resolution-strategy
+                    - python-version: '3.12'
+                      uv-resolution: 'lowest-direct'
 
         runs-on: ubuntu-24.04
         timeout-minutes: 30

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       hooks:
           - id: ruff-format
             exclude: ^docs/.*
-          - id: ruff
+          - id: ruff-check
             args: [--fix, --exit-non-zero-on-fix, --show-fixes]
 
     - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt


### PR DESCRIPTION
The Python 3.9 with resolution `lowest-direct` started failing for some unknown reason. Given the iminent migration to 3.12 we simply drop this particular job. I haven't removed testing on Python 3.9 entirely, since it might be useful in case we need to backport any fixes on 2.x release.