### PR TITLE
Remove reference to non-existent exception class

### DIFF
--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -16,7 +16,6 @@ from aiida import engine, orm
 
 # Local imports.
 from .nodes import NodesTreeWidget
-from .utils import exceptions
 
 
 class SubmitButtonWidget(ipw.VBox):
@@ -181,7 +180,8 @@ class ProcessFollowerWidget(ipw.VBox):
     def on_completed(self, function):
         """Run functions after a process has been completed."""
         if self._monitor is not None:
-            raise exceptions.CantRegisterCallbackError(function)
+            msg = "Can't register new on_completed callback functions, process following has already been initiated."
+            raise RuntimeError(msg)
         self._run_after_completed.append(function)
 
 


### PR DESCRIPTION
The `aiidalab_widgets_base.exceptions.CantRegisterCallbackError` does not (and has never!) existed! The code referencing it was added in #401, but the class itself was not added in that PR.

https://github.com/aiidalab/aiidalab-widgets-base/pull/401/files#diff-746417c33f0db806aa15e6a5c3531f1119f3ff874e23dcb9823bd8126d85cf61

Here I simply revert to the previous version of the code. Obviously, nobody has ever ran into this, this bug has been there since v2.0!

(found by running a ty type checker)