### PR TITLE
Remove pgtest dev dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ license_file = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Framework :: AiiDA
-    License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,6 @@ zip_safe = False
 [options.extras_require]
 dev =
     bumpver>=2023.1129
-    pgtest~=1.3
     pre-commit>=4.0
     pytest~=8.3.0
     pytest-cov~=5.0


### PR DESCRIPTION
We're using SQLite-based fixtures for testing now.