### PR TITLE
Replace `ipw.Output` with `ipw.VBox` across the codebase

### DIFF
--- a/aiidalab_widgets_base/computational_resources.py
+++ b/aiidalab_widgets_base/computational_resources.py
@@ -17,7 +17,6 @@ from aiida import common, orm, plugins
 from aiida.orm.utils.builders.computer import ComputerBuilder
 from aiida.transports.plugins import ssh as aiida_ssh_plugin
 from humanfriendly import InvalidSize, parse_size
-from IPython.display import clear_output, display
 from jinja2 import meta as jinja2_meta
 
 from .databases import ComputationalResourcesDatabaseWidget
@@ -114,8 +113,8 @@ class ComputationalResourcesWidget(ipw.VBox):
 
             selection_row.children += (self.btn_setup_new_code,)
 
-            self._setup_new_code_output = ipw.Output(
-                layout={"width": self._output_width}
+            self._setup_new_code_output = ipw.VBox(
+                layout={"width": self._output_width, "border": "none"}
             )
             children.append(self._setup_new_code_output)
 
@@ -200,24 +199,15 @@ class ComputationalResourcesWidget(ipw.VBox):
             return code_uuid
 
     def _setup_new_code(self, _=None):
-        with self._setup_new_code_output:
-            clear_output()
-            if self.btn_setup_new_code.value:
-                self._setup_new_code_output.layout = {
-                    "width": self._output_width,
-                    "border": "1px solid gray",
-                }
-
-                children = [
-                    self.resource_setup,
-                    self.setup_message,
-                ]
-                display(*children)
-            else:
-                self._setup_new_code_output.layout = {
-                    "width": self._output_width,
-                    "border": "none",
-                }
+        if self.btn_setup_new_code.value:
+            self._setup_new_code_output.layout.border = "1px solid gray"
+            self._setup_new_code_output.children = [
+                self.resource_setup,
+                self.setup_message,
+            ]
+        else:
+            self._setup_new_code_output.layout.border = "none"
+            self._setup_new_code_output.children = []
 
 
 class SshConnectionState(enum.Enum):
@@ -353,7 +343,7 @@ class SshComputerSetup(ipw.VBox):
         self._verification_mode.observe(
             self._on_verification_mode_change, names="value"
         )
-        self._verification_mode_output = ipw.Output()
+        self._verification_mode_output = ipw.VBox()
 
         self._continue_button = ipw.ToggleButton(
             description="Continue", layout={"width": "100px"}, value=False
@@ -622,22 +612,21 @@ class SshComputerSetup(ipw.VBox):
 
     def _on_verification_mode_change(self, change):
         """which verification mode is chosen."""
-        with self._verification_mode_output:
-            clear_output()
-            if self._verification_mode.value == "password":
-                self.password_box.layout.display = "block"
-            elif self._verification_mode.value == "public_key":
-                self.password_box.layout.display = "none"
-                public_key = self._ssh_folder / "id_rsa.pub"
-                if public_key.exists():
-                    display(
-                        ipw.HTML(
-                            f"""<pre style="background-color: #253239; color: #cdd3df; line-height: normal; custom=test">{public_key.read_text()}</pre>""",
-                            layout={"width": "100%"},
-                        )
+        self._verification_mode_output.children = []
+        if self._verification_mode.value == "password":
+            self.password_box.layout.display = "block"
+        elif self._verification_mode.value == "public_key":
+            self.password_box.layout.display = "none"
+            public_key = self._ssh_folder / "id_rsa.pub"
+            if public_key.exists():
+                self._verification_mode_output.children = [
+                    ipw.HTML(
+                        f"""<pre style="background-color: #253239; color: #cdd3df; line-height: normal; custom=test">{public_key.read_text()}</pre>""",
+                        layout={"width": "100%"},
                     )
-            else:
-                self.password_box.layout.display = "none"
+                ]
+        else:
+            self.password_box.layout.display = "none"
 
     def _reset(self):
         self.hostname.value = ""
@@ -1166,7 +1155,6 @@ class AiidaCodeSetup(ipw.VBox):
 
         btn_setup_code = ipw.Button(description="Setup code")
         btn_setup_code.on_click(self.on_setup_code)
-        self.setup_code_out = ipw.Output()
 
         children = [
             self.label,
@@ -1178,7 +1166,6 @@ class AiidaCodeSetup(ipw.VBox):
             self.prepend_text,
             self.append_text,
             btn_setup_code,
-            self.setup_code_out,
         ]
         super().__init__(children, **kwargs)
 
@@ -1189,100 +1176,97 @@ class AiidaCodeSetup(ipw.VBox):
 
     def on_setup_code(self, _=None):
         """Setup an AiiDA code."""
-        with self.setup_code_out:
-            clear_output()
-
-            if not self.label.value:
-                self.message = wrap_message(
-                    "Please provide a code label.",
-                    MessageLevel.WARNING,
-                )
-                return False
-
-            if not self.computer.value:
-                self.message = wrap_message(
-                    "Please select an existing computer.",
-                    MessageLevel.WARNING,
-                )
-                return False
-
-            items_to_configure = [
-                "label",
-                "description",
-                "default_calc_job_plugin",
-                "filepath_executable",
-                "use_double_quotes",
-                "prepend_text",
-                "append_text",
-            ]
-
-            containerized_code_additional_items = [
-                "image_name",
-                "engine_command",
-            ]
-
-            kwargs = {key: getattr(self, key).value for key in items_to_configure}
-
-            # Check for additional keys needed for orm.ContainerizedCode
-            for container_key in containerized_code_additional_items:
-                if container_key in self.code_setup:
-                    kwargs[container_key] = self.code_setup[container_key]
-
-            # set computer from its widget value the UUID of the computer.
-            computer = orm.load_computer(self.computer.value)
-
-            # Checking if the code with this name already exists
-            qb = orm.QueryBuilder()
-            qb.append(orm.Computer, filters={"uuid": computer.uuid}, tag="computer")
-            qb.append(
-                orm.Code,
-                with_computer="computer",
-                filters={"label": kwargs["label"]},
-            )
-            if qb.count() > 0:
-                self.message = wrap_message(
-                    f"Code {kwargs['label']}@{computer.label} already exists, skipping creation.",
-                    MessageLevel.INFO,
-                )
-                # TODO: (unkcpz) as callback function this return value not actually used
-                # meanwhile if the code already exists we still want to regard it as success (TBD).
-                # and the `_on_setup_code_success` callback functions will run.
-                # The return will break the flow and handle back the control to the caller.
-                # The proper way is to not return but raise an exception and handle it in the caller function
-                # for the afterward process.
-                return False
-
-            try:
-                if "image_name" in kwargs:
-                    code = orm.ContainerizedCode(computer=computer, **kwargs)
-                else:
-                    code = orm.InstalledCode(computer=computer, **kwargs)
-            except (common.exceptions.InputValidationError, KeyError) as exception:
-                self.message = wrap_message(
-                    f"Invalid input for code creation: <code>{exception}</code>",
-                    MessageLevel.ERROR,
-                )
-                return False
-
-            try:
-                code.store()
-                code.is_hidden = False
-            except common.exceptions.ValidationError as exception:
-                self.message = wrap_message(
-                    f"Unable to store the code: <code>{exception}</code>",
-                    MessageLevel.ERROR,
-                )
-                return False
-
-            for function in self._on_setup_code_success:
-                function()
-
+        if not self.label.value:
             self.message = wrap_message(
-                f"Code<{code.pk}> {code.full_label} created",
-                MessageLevel.SUCCESS,
+                "Please provide a code label.",
+                MessageLevel.WARNING,
             )
+            return False
 
-            return True
+        if not self.computer.value:
+            self.message = wrap_message(
+                "Please select an existing computer.",
+                MessageLevel.WARNING,
+            )
+            return False
+
+        items_to_configure = [
+            "label",
+            "description",
+            "default_calc_job_plugin",
+            "filepath_executable",
+            "use_double_quotes",
+            "prepend_text",
+            "append_text",
+        ]
+
+        containerized_code_additional_items = [
+            "image_name",
+            "engine_command",
+        ]
+
+        kwargs = {key: getattr(self, key).value for key in items_to_configure}
+
+        # Check for additional keys needed for orm.ContainerizedCode
+        for container_key in containerized_code_additional_items:
+            if container_key in self.code_setup:
+                kwargs[container_key] = self.code_setup[container_key]
+
+        # set computer from its widget value the UUID of the computer.
+        computer = orm.load_computer(self.computer.value)
+
+        # Checking if the code with this name already exists
+        qb = orm.QueryBuilder()
+        qb.append(orm.Computer, filters={"uuid": computer.uuid}, tag="computer")
+        qb.append(
+            orm.Code,
+            with_computer="computer",
+            filters={"label": kwargs["label"]},
+        )
+        if qb.count() > 0:
+            self.message = wrap_message(
+                f"Code {kwargs['label']}@{computer.label} already exists, skipping creation.",
+                MessageLevel.INFO,
+            )
+            # TODO: (unkcpz) as callback function this return value not actually used
+            # meanwhile if the code already exists we still want to regard it as success (TBD).
+            # and the `_on_setup_code_success` callback functions will run.
+            # The return will break the flow and handle back the control to the caller.
+            # The proper way is to not return but raise an exception and handle it in the caller function
+            # for the afterward process.
+            return False
+
+        try:
+            if "image_name" in kwargs:
+                code = orm.ContainerizedCode(computer=computer, **kwargs)
+            else:
+                code = orm.InstalledCode(computer=computer, **kwargs)
+        except (common.exceptions.InputValidationError, KeyError) as exception:
+            self.message = wrap_message(
+                f"Invalid input for code creation: <code>{exception}</code>",
+                MessageLevel.ERROR,
+            )
+            return False
+
+        try:
+            code.store()
+            code.is_hidden = False
+        except common.exceptions.ValidationError as exception:
+            self.message = wrap_message(
+                f"Unable to store the code: <code>{exception}</code>",
+                MessageLevel.ERROR,
+            )
+            return False
+
+        for function in self._on_setup_code_success:
+            function()
+
+        self.message = wrap_message(
+            f"Code<{code.pk}> {code.full_label} created",
+            MessageLevel.SUCCESS,
+        )
+
+        return True
 
     def on_setup_code_success(self, function):
         self._on_setup_code_success.append(function)

--- a/aiidalab_widgets_base/nodes.py
+++ b/aiidalab_widgets_base/nodes.py
@@ -7,7 +7,6 @@ import ipywidgets as ipw
 import traitlets as tl
 from aiida import common, engine, orm
 from aiida.cmdline.utils.ascii_vis import calc_info
-from IPython.display import clear_output, display
 
 
 class AiidaNodeTreeNode(ipytree.Node):
@@ -54,7 +53,7 @@ class UnknownTypeTreeNode(AiidaNodeTreeNode):
     icon = tl.Unicode("file").tag(sync=True)
 
 
-class NodesTreeWidget(ipw.Output):
+class NodesTreeWidget(ipw.VBox):
     """A tree widget for the structured representation of a nodes graph."""
 
     nodes = tl.Tuple().tag(trait=tl.Instance(orm.Node))
@@ -80,15 +79,7 @@ class NodesTreeWidget(ipw.Output):
         self._tree = ipytree.Tree()
         self._tree.observe(self._observe_tree_selected_nodes, ["selected_nodes"])
 
-        super().__init__(**kwargs)
-
-    def _refresh_output(self):
-        # There appears to be a bug in the ipytree implementation that sometimes
-        # causes the output to not be properly cleared. We therefore refresh the
-        # displayed tree upon change of the process trait.
-        with self:
-            clear_output()
-            display(self._tree)
+        super().__init__(children=[self._tree], **kwargs)
 
     def _observe_tree_selected_nodes(self, change):
         for node in change["new"]:
@@ -131,7 +122,6 @@ class NodesTreeWidget(ipw.Output):
             )
         )
         self.update()
-        self._refresh_output()
 
     @classmethod
     def _to_tree_node(cls, node, name=None, **kwargs):

--- a/aiidalab_widgets_base/process.py
+++ b/aiidalab_widgets_base/process.py
@@ -5,10 +5,10 @@
 from __future__ import annotations
 
 import inspect
-import sys
 import threading
 import traceback
 import warnings
+from html import escape
 
 import ipywidgets as ipw
 import traitlets as tl
@@ -200,7 +200,7 @@ class ProcessMonitor(tl.HasTraits):
         self._monitor_thread_stop = threading.Event()
         self._monitor_thread_lock = threading.Lock()
 
-        self.log_widget: ipw.Output | None = kwargs.pop("log_widget", None)
+        self.log_widget: ipw.VBox | None = kwargs.pop("log_widget", None)
 
         super().__init__(**kwargs)
 
@@ -244,11 +244,13 @@ class ProcessMonitor(tl.HasTraits):
                     else:
                         func()
                 except Exception:  # ruff: ignore[BLE001]
+                    formatted = traceback.format_exc()
                     if self.log_widget:
-                        with self.log_widget:
-                            traceback.print_exc(file=sys.stdout)
+                        self.log_widget.children += (
+                            ipw.HTML(f"<pre>{escape(formatted)}</pre>"),
+                        )
                     warnings.warn(
-                        f"WARNING: The callback function {func.__name__!r} was disabled due to an error:\n{traceback.format_exc()}",
+                        f"WARNING: The callback function {func.__name__!r} was disabled due to an error:\n{formatted}",
                         stacklevel=2,
                     )
                     disabled_funcs.add(func)

--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -24,7 +24,7 @@ from aiida import cmdline, orm
 from aiida.orm.nodes.data.structure import _get_dimensionality
 from aiida.tools.query.formatting import format_process_state, format_relative_time
 from ase.data import colors
-from IPython.display import clear_output, display
+from IPython.display import display
 from matplotlib.colors import to_rgb
 
 from .dicts import RGB_COLORS, Colors, Radius
@@ -116,7 +116,7 @@ class AiidaNodeViewWidget(ipw.VBox):
     node = tl.Instance(orm.Node, allow_none=True)
 
     def __init__(self, **kwargs):
-        self._output = ipw.Output()
+        self._output = ipw.HTML()
         self.node_views = {}
         self.node_view_loading_message = LoadingWidget("Loading node view")
         super().__init__(**kwargs)
@@ -128,8 +128,7 @@ class AiidaNodeViewWidget(ipw.VBox):
         if node == change["old"]:
             return
         if not node:
-            with self._output:
-                clear_output()
+            self._output.value = ""
             self.children = []
             return
 
@@ -142,10 +141,7 @@ class AiidaNodeViewWidget(ipw.VBox):
             self.node_views[node.uuid] = node_view
             self.children = [node_view]
         else:
-            with self._output:
-                clear_output()
-                if change["new"]:
-                    display(node_view)
+            self._output.value = f"<pre>{escape(str(node_view))}</pre>"
             self.children = [self._output]
 
 

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 
 import pytest
-from aiida import orm
+from aiida import common, orm
 
 from aiidalab_widgets_base import computational_resources
 from aiidalab_widgets_base.computational_resources import (
@@ -280,6 +280,62 @@ def test_aiida_code_setup(aiida_localhost):
     assert widget.filepath_executable.value == ""
     assert widget.prepend_text.value == ""
     assert widget.append_text.value == ""
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_aiida_code_setup_message_branches(aiida_localhost, monkeypatch):
+    """Test the warning/error/info branches of AiidaCodeSetup.on_setup_code."""
+    widget = computational_resources.AiidaCodeSetup()
+
+    computer_label = aiida_localhost.label
+    code_setup = {
+        "label": "bash-test-2",
+        "computer": computer_label,
+        "description": "Bash interpreter",
+        "filepath_executable": "/bin/bash",
+        "prepend_text": "",
+        "append_text": "",
+        "default_calc_job_plugin": "core.arithmetic.add",
+    }
+    widget.code_setup = code_setup
+
+    # Missing label.
+    widget.label.value = ""
+    assert not widget.on_setup_code()
+    assert "Please provide a code label" in widget.message
+    widget.label.value = code_setup["label"]
+
+    # Missing computer.
+    widget.computer.value = None
+    assert not widget.on_setup_code()
+    assert "Please select an existing computer" in widget.message
+    widget.computer.value = orm.load_computer(computer_label).uuid
+
+    # Code already exists: succeed once, then fail on the second attempt.
+    assert widget.on_setup_code()
+    assert not widget.on_setup_code()
+    assert "already exists, skipping creation" in widget.message
+
+    # Invalid input for code creation: the constructor call itself fails.
+    widget.label.value = "bash-test-invalid"
+
+    def _raise_input_validation_error(**_):
+        raise common.exceptions.InputValidationError("bad input")
+
+    monkeypatch.setattr(orm, "InstalledCode", _raise_input_validation_error)
+    assert not widget.on_setup_code()
+    assert "Invalid input for code creation" in widget.message
+    monkeypatch.undo()
+
+    # Storing the code fails after successful construction.
+    widget.label.value = "bash-test-store-fail"
+
+    def _raise_store_error(self):
+        raise common.exceptions.ValidationError("cannot store")
+
+    monkeypatch.setattr(orm.InstalledCode, "store", _raise_store_error)
+    assert not widget.on_setup_code()
+    assert "Unable to store the code" in widget.message
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -283,6 +283,39 @@ def test_aiida_code_setup(aiida_localhost):
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
+def test_aiida_code_setup_containerized_code(aiida_localhost):
+    """Test that a `ContainerizedCode` is created when `image_name` is present in code_setup.
+
+    `image_name`/`engine_command` are not backed by widget fields; they only ever come from
+    `code_setup` directly, which is what routes `on_setup_code` into the ContainerizedCode
+    branch instead of InstalledCode.
+    """
+    widget = computational_resources.AiidaCodeSetup()
+
+    computer_label = aiida_localhost.label
+    code_label = "containerized-bash-test"
+    code_setup = {
+        "label": code_label,
+        "computer": computer_label,
+        "description": "Containerized bash interpreter",
+        "filepath_executable": "/bin/bash",
+        "prepend_text": "",
+        "append_text": "",
+        "default_calc_job_plugin": "core.arithmetic.add",
+        "image_name": "docker://alpine",
+        "engine_command": "singularity exec --bind $PWD:$PWD {image_name}",
+    }
+
+    widget.code_setup = code_setup
+    assert widget.on_setup_code(), f"ERROR: Code setup failed! {widget.message}"
+
+    code = orm.load_code(f"{code_label}@{computer_label}")
+    assert isinstance(code, orm.ContainerizedCode)
+    assert code.image_name == "docker://alpine"
+    assert code.engine_command == "singularity exec --bind $PWD:$PWD {image_name}"
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
 def test_aiida_code_setup_message_branches(aiida_localhost, monkeypatch):
     """Test the warning/error/info branches of AiidaCodeSetup.on_setup_code."""
     widget = computational_resources.AiidaCodeSetup()

--- a/tests/test_computational_resources.py
+++ b/tests/test_computational_resources.py
@@ -814,3 +814,52 @@ def test_optional_code_fetching(pw_code):
     assert len(widget.code_select_dropdown.options) != 0
     widget = ComputationalResourcesWidget(fetch_codes=False)
     assert len(widget.code_select_dropdown.options) == 0
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_setup_new_code_toggle():
+    """Test that toggling 'Setup new code' shows/hides the setup panel."""
+    widget = ComputationalResourcesWidget(fetch_codes=False)
+
+    assert list(widget._setup_new_code_output.children) == []
+    assert widget._setup_new_code_output.layout.border == "none"
+
+    widget.btn_setup_new_code.value = True
+    assert list(widget._setup_new_code_output.children) == [
+        widget.resource_setup,
+        widget.setup_message,
+    ]
+    assert widget._setup_new_code_output.layout.border == "1px solid gray"
+
+    widget.btn_setup_new_code.value = False
+    assert list(widget._setup_new_code_output.children) == []
+    assert widget._setup_new_code_output.layout.border == "none"
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_ssh_verification_mode_public_key(tmp_path):
+    """Test that switching to 'public_key' verification mode renders the key once available."""
+    widget = computational_resources.SshComputerSetup(ssh_folder=tmp_path)
+
+    # No key on disk yet: switching to public_key hides the password box but shows nothing else.
+    widget._verification_mode.value = "public_key"
+    assert widget.password_box.layout.display == "none"
+    assert list(widget._verification_mode_output.children) == []
+
+    # Once a key is written, re-selecting public_key mode displays it.
+    (tmp_path / "id_rsa.pub").write_text("ssh-rsa AAAAtest key-comment")
+    widget._verification_mode.value = "password"
+    widget._verification_mode.value = "public_key"
+    children = widget._verification_mode_output.children
+    assert len(children) == 1
+    assert "ssh-rsa AAAAtest key-comment" in children[0].value
+
+    # Switching back to password mode shows the password box and clears the panel.
+    widget._verification_mode.value = "password"
+    assert widget.password_box.layout.display == "block"
+    assert list(widget._verification_mode_output.children) == []
+
+    # mfa mode: neither the password box nor the key panel is shown.
+    widget._verification_mode.value = "mfa"
+    assert widget.password_box.layout.display == "none"
+    assert list(widget._verification_mode_output.children) == []

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,3 +1,4 @@
+import ipywidgets as ipw
 import pytest
 from aiida import engine, orm
 from aiida.workflows.arithmetic.multiply_add import MultiplyAddWorkChain
@@ -76,3 +77,27 @@ def test_process_monitor(
 def test_process_nodes_tree_widget(multiply_add_completed_workchain):
     """Test ProcessNodesTreeWidget with a simple `WorkChainNode`."""
     awb.ProcessNodesTreeWidget(value=multiply_add_completed_workchain.uuid)
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_process_monitor_log_widget(multiply_add_completed_workchain):
+    """Test that a failing callback's traceback is written to `log_widget`."""
+
+    def failing_callback():
+        raise RuntimeError("callback exploded")
+
+    def run_and_join():
+        widget = awb.ProcessMonitor(
+            value=multiply_add_completed_workchain.uuid,
+            callbacks=[failing_callback],
+            log_widget=log_widget,
+        )
+        widget.join()
+
+    log_widget = ipw.VBox()
+    with pytest.warns(UserWarning, match="failing_callback"):
+        run_and_join()
+
+    assert len(log_widget.children) == 1
+    assert isinstance(log_widget.children[0], ipw.HTML)
+    assert "callback exploded" in log_widget.children[0].value

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -1,7 +1,5 @@
 import base64
 import re
-import sys
-from io import StringIO
 from pathlib import Path
 
 import ase
@@ -510,18 +508,12 @@ def test_loading_viewer_using_process_type(generate_calc_job_node):
 
 
 def test_node_view_for_non_widget_viewer():
-    """Test that a node with no registered viewer is displayed in an output widget"""
-
-    # Intercepting stdout because `ipw.Output` does not
-    # store outputs in non-interactive environments.
-    captured = StringIO()
-    sys.stdout = captured
-
+    """Test that a node with no registered viewer is rendered as text."""
     node_view = viewers.AiidaNodeViewWidget()
     node = orm.Int(1)
     node_view.node = node
     assert node_view.children[0] is node_view._output
-    assert str(node) in sys.stdout.getvalue()
+    assert str(node) in node_view._output.value
 
 
 def test_node_view_caching():
@@ -534,12 +526,7 @@ def test_node_view_caching():
 
     # orm.Int doesn't have a dedicated viewer
     # so it will not be cached.
-    stdout = sys.stdout
-    with StringIO() as captured:
-        sys.stdout = captured
-        node_view.node = orm.Int(2)
-    sys.stdout = stdout
-
+    node_view.node = orm.Int(2)
     assert len(node_view.node_views) == 1
 
     node_view.node = None


### PR DESCRIPTION
`ipw.Output` has caused some display bugs in AiiDAlab before
(aiidalab/aiidalab-home#185), where content written into an `Output`
failed to render. In this PR, we replace `Output` with `VBox` everywhere.
`VBox` keeps children as an ordinary trait in the codebase.

fixes #717 