### PR TITLE
Add pre-commit job to run ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,27 @@ concurrency:
 
 jobs:
 
+    pre-commit:
+
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+
+        steps:
+
+            - uses: actions/checkout@v7
+
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v10.0.1
+              with:
+                  python-version: '3.12'
+                  activate-environment: true
+
+            - name: Install dependencies
+              run: uv pip install -e .[dev,optimade,smiles]
+
+            - name: Run pre-commit
+              run: pre-commit run --all-files || (git status --short; git diff; exit 1)
+
     test-notebooks:
 
         strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,7 @@ jobs:
             - name: Install dependencies
               run: uv pip install -e .[dev,optimade,smiles]
 
-            - name: Run pre-commit
-              run: pre-commit run --all-files || (git status --short; git diff; exit 1)
+            - uses: j178/prek-action@v3.0.0
 
     test-notebooks:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ requires-python = '>=3.9'
 dev = [
     "bumpver>=2023.1129",
     "pre-commit>=4.0",
-    "ty==0.0.69",
+    "ty==0.0.75",
     "pytest~=8.3.0",
     "pytest-cov~=5.0",
     "pytest-docker~=3.1.0",


### PR DESCRIPTION
In #781 I've added ty as a pre-commit hook, but I forgot to add a manual pre-commit job to CI, because ty cannot run on `pre-commit.ci` service.

This is the same setup we have in aiidalab-home (and aiidalab with mypy)