### PR TITLE
Remove custom ListOrTuppleError

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -5,6 +5,7 @@ import functools
 import io
 import pathlib
 import tempfile
+from collections.abc import Sequence
 
 import ase
 import ase.cell
@@ -21,7 +22,6 @@ from .utils import (
     StatusHTML,
     _restore_spglib_old_error_handling,
     _set_spglib_old_error_handling,
-    exceptions,
     get_ase_from_file,
     get_formula,
 )
@@ -181,11 +181,13 @@ class StructureManagerWidget(ipw.VBox):
 
     def _structure_importers(self, importers):
         """Preparing structure importers."""
-        if not isinstance(importers, (list, tuple)):
-            raise exceptions.ListOrTuppleError(importers)
-
         if not importers:
             return []
+
+        if not isinstance(importers, Sequence):
+            raise TypeError(
+                f"`importers` argument should be a Sequence, got {type(importers)}."
+            )
 
         # Otherwise making one tab per importer.
         importers_tab = ipw.Tab()

--- a/aiidalab_widgets_base/utils/exceptions.py
+++ b/aiidalab_widgets_base/utils/exceptions.py
@@ -1,7 +1,0 @@
-class ListOrTuppleError(TypeError):
-    """Raised when the provided value is not a list or a tupple."""
-
-    def __init__(self, value):
-        super().__init__(
-            f"The provided value {value!r} is not a list or a tupple, but a {type(value)}."
-        )

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -28,6 +28,18 @@ def file_upload_change():
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_invalid_importers_type(
+    structure_data_object,
+):
+    """Test the `StructureManagerWidget` raises TypeError for invalid importers argument."""
+
+    with pytest.raises(TypeError, match="`importers` argument should be a Sequence"):
+        awb.StructureManagerWidget(
+            importers=1,
+        )
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_manager_widget_different_number_of_importers_or_editors(
     structure_data_object,
 ):


### PR DESCRIPTION
This custom exception class is only used in one place, and is kind of a weird exception to have anyways so let's remove it for the v3 release. 

In general, I don't think runtime-checking of types like this goes against python duck typing philosophy and errors like this should rather be called by a static type checker, so I'd be fine to also just remove this code altogether. Also notice that we only do this check for `importers`, and not e.g. for `editors`.

(This is I think a last cleanup I wanted to do before v3)