### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,9 @@ jobs:
     test-package:
 
         strategy:
+            fail-fast: false
             matrix:
-                python-version: ['3.12', '3.13']
+                python-version: ['3.12']
                 uv-resolution: ['highest']
                 include:
                   # Make sure lowest-support package versions work

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,10 @@ jobs:
             - name: Check out app
               uses: actions/checkout@v7
 
-            - name: Set up Python
-              uses: actions/setup-python@v7
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: '3.12'
-
-            - name: Setup uv
-              uses: astral-sh/setup-uv@v7
-              with:
                   activate-environment: true
 
             - name: Install package test dependencies
@@ -107,7 +103,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.9', '3.12']
+                python-version: ['3.12', '3.13']
                 uv-resolution: ['highest']
                 include:
                   # Make sure lowest-support package versions work
@@ -127,14 +123,10 @@ jobs:
             - name: Check out app
               uses: actions/checkout@v7
 
-            - name: Set up Python
-              uses: actions/setup-python@v7
+            - name: Setup uv
+              uses: astral-sh/setup-uv@v10.0.1
               with:
                   python-version: ${{ matrix.python-version }}
-
-            - name: Setup uv
-              uses: astral-sh/setup-uv@v7
-              with:
                   activate-environment: true
 
             - name: Install package

--- a/aiidalab_widgets_base/bug_report.py
+++ b/aiidalab_widgets_base/bug_report.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import textwrap
 import zlib
-from typing import Callable
+from collections.abc import Callable
 from urllib import parse
 
 import ipywidgets as ipw

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "PyCifRW~=4.4",
     "aiida-core>=2.8,<3",
     "ansi2html~=1.7",
-    "ase~=3.18",
+    "ase~=3.23",
     "humanfriendly~=10.0",
     "ipytree~=0.2",
     "traitlets~=5.4",
@@ -46,7 +46,7 @@ dev = [
     "bumpver>=2023.1129",
     "pre-commit>=4.0",
     "ty==0.0.77",
-    "pytest~=8.3.0",
+    "pytest~=8.4.0",
     "pytest-cov~=5.0",
     "pytest-docker~=3.1.0",
     "pytest-selenium~=4.1.0",
@@ -54,7 +54,7 @@ dev = [
     "selenium~=4.23.0",
 ]
 optimade = ["ipyoptimade>=1.2.1,<2"]
-smiles = ["rdkit>=2021.09.2"]
+smiles = ["rdkit>=2024.9.6"]
 docs = [
     "sphinx~=7.3",
     "sphinx-design~=0.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "PyCifRW~=4.4",
-    "aiida-core>=2.7,<3",
+    "aiida-core>=2.8,<3",
     "ansi2html~=1.7",
     "ase~=3.18",
     "humanfriendly~=10.0",
@@ -39,7 +39,7 @@ dependencies = [
 description = "Reusable widgets for AiiDAlab applications."
 license = {file = 'LICENSE.txt'}
 readme = 'README.md'
-requires-python = '>=3.9'
+requires-python = '>=3.12'
 
 [project.optional-dependencies]
 dev = [
@@ -94,7 +94,6 @@ filterwarnings = [
 [tool.ruff]
 line-length = 88
 show-fixes = true
-target-version = "py39"
 
 [tool.ruff.lint]
 ignore = ["RUF012"]


### PR DESCRIPTION
I think with the v3 release now ready we can drop the python 3.9 support.

If we wanted to keep possible backports easier, we could also instruct ruff to still have minimum python 3.9 support. 