### PR TITLE
Fix `StructureManagerWidget` defaulting to `CifData`

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -102,11 +102,19 @@ class StructureManagerWidget(ipw.VBox):
         self.structure_label = ipw.Text(description="Label")
         self.structure_description = ipw.Text(description="Description")
 
+        # Validate node_class before it's used to pick the format selector's default.
+        if node_class is not None and node_class not in self.SUPPORTED_DATA_FORMATS:
+            raise ValueError(
+                f"Unknown data format '{node_class}'. Options: {list(self.SUPPORTED_DATA_FORMATS.keys())}"
+            )
+
         # Store format selector.
+        default_node_class = node_class or "StructureData"
         data_format = ipw.RadioButtons(
             options=tuple(
                 (key, value) for key, value in self.SUPPORTED_DATA_FORMATS.items()
             ),
+            value=self.SUPPORTED_DATA_FORMATS[default_node_class],
             description="Data type:",
         )
         tl.link((data_format, "label"), (self, "node_class"))
@@ -114,14 +122,11 @@ class StructureManagerWidget(ipw.VBox):
         # Store button, store class selector, description.
         store_and_description = [self.btn_store] if storable else []
 
+        # `node_class` is already set by the link above, from the selector's
+        # initial value. The selector itself is only shown when the caller left
+        # the choice open.
         if node_class is None:
             store_and_description.append(data_format)
-        elif node_class in self.SUPPORTED_DATA_FORMATS:
-            self.node_class = node_class
-        else:
-            raise ValueError(
-                f"Unknown data format '{node_class}'. Options: {list(self.SUPPORTED_DATA_FORMATS.keys())}"
-            )
 
         select_panel = ipw.Accordion(
             children=self._structure_importers(importers),

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -172,6 +172,8 @@ def test_structure_manager_widget_honours_explicit_node_class(node_class):
 def test_structure_manager_widget_rejects_unknown_node_class():
     with pytest.raises(ValueError, match="Unknown data format"):
         awb.StructureManagerWidget(importers=[], node_class="NotAFormat")
+
+
 def test_structure_manager_widget_stores_viewer_representations_in_extras():
     style_id = awb.viewers.encode_representation_style_id(
         representation_type="spacefill",

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -149,6 +149,33 @@ def test_structure_manager_widget(structure_data_object):
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_widget_defaults_to_structure_data(structure_data_object):
+    """The declared traitlets default must survive the RadioButtons link.
+
+    The trait is only half of it: what matters downstream is that a structure
+    stored without an explicit `node_class` really is a `StructureData`.
+    """
+    widget = awb.StructureManagerWidget(importers=[])
+    assert widget.node_class == "StructureData"
+
+    widget.input_structure = structure_data_object.get_ase()
+    widget.btn_store.click()
+    assert isinstance(widget.structure_node, orm.StructureData)
+
+
+@pytest.mark.parametrize("node_class", ["StructureData", "CifData"])
+def test_structure_manager_widget_honours_explicit_node_class(node_class):
+    """An explicit node_class is reflected in the trait."""
+    widget = awb.StructureManagerWidget(importers=[], node_class=node_class)
+    assert widget.node_class == node_class
+
+
+def test_structure_manager_widget_rejects_unknown_node_class():
+    with pytest.raises(ValueError, match="Unknown data format"):
+        awb.StructureManagerWidget(importers=[], node_class="NotAFormat")
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_browser_widget(structure_data_object, monkeypatch):
     """Test the `StructureBrowserWidget`."""
     structure_browser_widget = awb.StructureBrowserWidget()
@@ -193,6 +220,8 @@ def test_structure_browser_widget(structure_data_object, monkeypatch):
 
     # Loading by PK should respect the configured query types.
     int_node = orm.Int(1).store()
+    # `pk` is typed `int | None`; a stored node always has one.
+    assert int_node.pk is not None
     structure_browser_widget.pk_input.value = str(int_node.pk)
     structure_browser_widget._on_load_button_clicked()
 


### PR DESCRIPTION
The `RadioButtons` format selector had no explicit initial value, so it picked its first option, and the `tl.link` to `node_class` immediately overwrote the declared `StructureData` default with `CifData`.

Set the selector's initial value from `node_class` (defaulting to `StructureData`) so it agrees with the trait from construction, and validate `node_class` upfront instead of after building the widget.

fixes #813 