### PR TITLE
Drop the special-cased default representation

### DIFF
--- a/aiidalab_widgets_base/viewers.py
+++ b/aiidalab_widgets_base/viewers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import copy
 import csv
+import enum
 import io
 import os
 import pathlib
@@ -171,7 +172,14 @@ class DictViewer(ipw.VBox):
 
 _DEFAULT_REPRESENTATION_PREFIX = "_aiidalab_viewer_representation_"
 VIEWER_REPRESENTATIONS_EXTRA = "aiidalab_viewer_representations"
-_DEFAULT_REPRESENTATION_STYLE_ID = f"{_DEFAULT_REPRESENTATION_PREFIX}default"
+
+
+class _AtomMarker(enum.IntEnum):
+    IN = 1  # Atom is included in the representation.
+    OUT = -1  # Atom is excluded from the representation.
+    UNASSIGNED = 0  # Atom is unassigned to any representation. Temporary state.
+
+
 _REPRESENTATION_TYPE_TO_TOKEN = {
     "ball+stick": "ballstick",
     "spacefill": "spacefill",
@@ -207,8 +215,9 @@ def encode_representation_style_id(
 def parse_representation_style_id(style_id: str) -> dict | None:
     """Parse style metadata encoded in a representation array name.
 
-    Old opaque representation ids intentionally return ``None`` so they keep the
-    historical default display settings.
+    A name that carries no style metadata returns ``None``: the representation is
+    then displayed with the default settings, and its array is renamed into the
+    encoded form the next time the representation is applied.
     """
     match = _REPRESENTATION_STYLE_PATTERN.match(style_id)
     if match is None:
@@ -233,27 +242,19 @@ class NglViewerRepresentation(ipw.HBox):
 
     viewer_class = None  # The structure viewer class that contains this representation.
 
-    def __init__(self, style_id, indices=None, deletable=True, atom_show_threshold=1):
+    def __init__(self, style_id, indices=None):
         """Initialize the representation.
 
         style_id: str
-            Unique identifier for the representation.
+            Unique identifier for the representation, encoding its display style.
         indices: list
             List of indices to be displayed.
-        deletable: bool
-            If True, add a button to delete the representation.
-        atom_show_threshold: int
-            only show the atom if the corresponding value in the representation array is larger or equal than this threshold.
         """
 
-        self.atom_show_threshold = atom_show_threshold
         self.style_id = style_id
         style_metadata = parse_representation_style_id(style_id)
         self._style_token = (
             style_metadata["token"] if style_metadata is not None else shortuuid.uuid()
-        )
-        self._sync_style_id_with_settings = (
-            style_id != _DEFAULT_REPRESENTATION_STYLE_ID and style_metadata is not None
         )
 
         self.show = ipw.Checkbox(
@@ -301,7 +302,7 @@ class NglViewerRepresentation(ipw.HBox):
             button_style="danger",
             layout={
                 "width": "50px",
-                "visibility": "visible" if deletable else "hidden",
+                "visibility": "hidden",
             },
         )
         self.delete_button.on_click(self.delete_myself)
@@ -329,7 +330,7 @@ class NglViewerRepresentation(ipw.HBox):
 
     def _refresh_style_id_from_widget_values(self, structure: ase.Atoms | None):
         """Keep encoded style ids aligned with the current representation widgets."""
-        if not self._sync_style_id_with_settings or self.viewer_class is None:
+        if self.viewer_class is None:
             return
         new_style_id = encode_representation_style_id(
             self.viewer_class.REPRESENTATION_PREFIX,
@@ -349,18 +350,18 @@ class NglViewerRepresentation(ipw.HBox):
         """Add representation array to the structure object. If the array already exists, update it."""
         if structure:
             self._refresh_style_id_from_widget_values(structure)
-            array_representation = np.full(len(structure), -1, dtype=int)
+            array_representation = np.full(len(structure), _AtomMarker.OUT, dtype=int)
             selection = np.array(
                 string_range_to_list(self.selection.value, shift=-1)[0], dtype=int
             )
             # Only attempt to display the existing atoms.
-            array_representation[selection[selection < len(structure)]] = 1
+            array_representation[selection[selection < len(structure)]] = _AtomMarker.IN
             structure.set_array(self.style_id, array_representation)
 
     def atoms_in_representation(self, structure: ase.Atoms | None = None):
         """Return an array of booleans indicating which atoms are present in the representation."""
         if structure and self.style_id in structure.arrays:
-            return structure.arrays[self.style_id] >= self.atom_show_threshold
+            return structure.arrays[self.style_id] == _AtomMarker.IN
         natoms = 0 if not structure else len(structure)
         return np.zeros(natoms, dtype=bool)
 
@@ -410,7 +411,6 @@ class _StructureDataBaseViewer(ipw.VBox):
     DEFAULT_SELECTION_RADIUS = 6
     DEFAULT_SELECTION_COLOR = "green"
     REPRESENTATION_PREFIX = _DEFAULT_REPRESENTATION_PREFIX
-    DEFAULT_REPRESENTATION = _DEFAULT_REPRESENTATION_STYLE_ID
     DEFAULT_VIEW_ORIENTATION = [
         -1.0,
         0.0,
@@ -665,12 +665,11 @@ class _StructureDataBaseViewer(ipw.VBox):
 
         self.representation_output = ipw.VBox()
 
-        # The default representation is always present and cannot be deleted.
+        # The viewer always holds at least one representation; the last remaining
+        # one cannot be deleted.
         self._all_representations = [
             NglViewerRepresentation(
-                style_id=self.DEFAULT_REPRESENTATION,
-                deletable=False,
-                atom_show_threshold=0,
+                style_id=encode_representation_style_id(self.REPRESENTATION_PREFIX)
             )
         ]
 
@@ -754,6 +753,12 @@ class _StructureDataBaseViewer(ipw.VBox):
         self.representation_output.children = change["new"]
         if change["new"]:
             self._all_representations[-1].viewer_class = self
+        # Deleting the last representation would leave nothing to display.
+        deletable = len(change["new"]) > 1
+        for representation in change["new"]:
+            representation.delete_button.layout.visibility = (
+                "visible" if deletable else "hidden"
+            )
 
     def _povray_cylinder(self, v1, v2, radius, color):
         """Create a cylinder for POVRAY."""
@@ -1540,12 +1545,25 @@ class StructureDataViewer(_StructureDataBaseViewer):
                 structure, structure.get_ase()
             )
 
-        # Add default representation array if it is not present.
-        # This will make sure that the new structure is displayed at the beginning.
-        if self.DEFAULT_REPRESENTATION not in structure.arrays:
+        # Seed a representation array if the structure carries none, so that a
+        # newly loaded structure is displayed in full. It reuses the style of the
+        # first representation, which the viewer always has.
+        style_ids = [
+            style_id
+            for style_id in structure.arrays
+            if style_id.startswith(self.REPRESENTATION_PREFIX)
+        ]
+        if not style_ids:
+            style_ids = [self._all_representations[0].style_id]
             structure.set_array(
-                self.DEFAULT_REPRESENTATION,
-                np.zeros(len(structure), dtype=int),
+                style_ids[0], np.full(len(structure), _AtomMarker.IN, dtype=int)
+            )
+
+        # Only the first representation displays newly loaded atoms (UNASSIGNED).
+        for index, style_id in enumerate(style_ids):
+            array = structure.arrays[style_id]
+            array[array == _AtomMarker.UNASSIGNED] = (
+                _AtomMarker.IN if index == 0 else _AtomMarker.OUT
             )
         return structure  # This also includes the case when the structure is None.
 
@@ -1578,7 +1596,7 @@ class StructureDataViewer(_StructureDataBaseViewer):
             except ValueError:
                 self._add_representation(
                     style_id=style_id,
-                    indices=np.where(structure.arrays[style_id] >= 1)[0],
+                    indices=np.where(structure.arrays[style_id] == _AtomMarker.IN)[0],
                     apply=False,
                 )
         # Drop representations that are not present in the new structure.

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -202,10 +202,6 @@ def test_structure_manager_widget_stores_viewer_representations_in_extras():
     assert stored is not None
 
     assert stored.base.extras.get(awb.viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
-        # Applying the default representation turns its unapplied placeholder
-        # array (`[0, 0]`, "included" only via the default's atom_show_threshold=0)
-        # into the canonical "explicitly included" encoding used everywhere else.
-        awb.viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, 1],
         style_id: [1, -1],
     }
 
@@ -242,7 +238,7 @@ def test_structure_manager_widget_store_structure_applies_pending_selection_edit
     stored = structure_manager_widget.structure_node
     assert stored is not None
     assert stored.base.extras.get(awb.viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
-        awb.viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, -1]
+        structure_manager_widget.viewer._all_representations[0].style_id: [1, -1]
     }
 
 
@@ -281,7 +277,7 @@ def test_structure_manager_widget_stores_representations_via_calcfunction():
     assert "user_modifications" in stored.creator.process_label
 
     assert stored.base.extras.get(awb.viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
-        awb.viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, -1]
+        structure_manager_widget.viewer._all_representations[0].style_id: [1, -1]
     }
     assert node.base.extras.get(awb.viewers.VIEWER_REPRESENTATIONS_EXTRA, None) is None
 
@@ -309,7 +305,7 @@ def test_structure_manager_widget_updates_stored_representations_extra():
     structure_manager_widget.viewer.btn_store_representations.click()
 
     assert node.base.extras.get(awb.viewers.VIEWER_REPRESENTATIONS_EXTRA) == {
-        awb.viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, -1]
+        structure_manager_widget.viewer._all_representations[0].style_id: [1, -1]
     }
 
 

--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -10,6 +10,9 @@ from aiida import orm
 
 from aiidalab_widgets_base import viewers
 
+# A representation array name that carries no encoded style.
+UNSTYLED_STYLE_ID = f"{viewers._DEFAULT_REPRESENTATION_PREFIX}unstyled"
+
 
 @pytest.fixture
 def ch_structure():
@@ -123,12 +126,16 @@ def test_folder_data_viewer(folder_data_object):
 
 @pytest.mark.usefixtures("aiida_profile_clean")
 def test_structure_data_viewer_storage(monkeypatch, tmp_path, structure_data_object):
+    # The representation array name ends in a random token, and it is written to
+    # the downloaded file as a column header. Pin it so the payload is stable.
+    monkeypatch.setattr(viewers.shortuuid, "uuid", lambda: "teststyletoken")
+
     v = viewers.viewer(structure_data_object)
     assert isinstance(v, viewers.StructureDataViewer)
 
     # Check the `_prepare_payload` function used for downloading.
     format_cases = {
-        "Extended xyz": """MgpMYXR0aWNlPSIzLjg0NzM3IDAuMCAwLjAgMS45MjM2ODUgMy4zMzE5MiAwLjAgMS45MjM2ODUgMS4xMTA2NCAzLjE0MTM2NCIgUHJvcGVydGllcz1zcGVjaWVzOlM6MTpwb3M6UjozOm1hc3NlczpSOjE6X2FpaWRhbGFiX3ZpZXdlcl9yZXByZXNlbnRhdGlvbl9kZWZhdWx0Okk6MSBwYmM9IlQgVCBUIgpTaSAgICAgICAwLjAwMDAwMDAwICAgICAgIDAuMDAwMDAwMDAgICAgICAgMC4wMDAwMDAwMCAgICAgIDI4LjA4NTUwMDAwICAgICAgICAwClNpICAgICAgIDEuOTIzNjg1MDAgICAgICAgMS4xMTA2NDAwMCAgICAgICAwLjc4NTM0MTAwICAgICAgMjguMDg1NTAwMDAgICAgICAgIDAK""",
+        "Extended xyz": """MgpMYXR0aWNlPSIzLjg0NzM3IDAuMCAwLjAgMS45MjM2ODUgMy4zMzE5MiAwLjAgMS45MjM2ODUgMS4xMTA2NCAzLjE0MTM2NCIgUHJvcGVydGllcz1zcGVjaWVzOlM6MTpwb3M6UjozOm1hc3NlczpSOjE6X2FpaWRhbGFiX3ZpZXdlcl9yZXByZXNlbnRhdGlvbl9iYWxsc3RpY2tfcjNfZWxlbWVudF90ZXN0c3R5bGV0b2tlbjpJOjEgcGJjPSJUIFQgVCIKU2kgICAgICAgMC4wMDAwMDAwMCAgICAgICAwLjAwMDAwMDAwICAgICAgIDAuMDAwMDAwMDAgICAgICAyOC4wODU1MDAwMCAgICAgICAgMQpTaSAgICAgICAxLjkyMzY4NTAwICAgICAgIDEuMTEwNjQwMDAgICAgICAgMC43ODUzNDEwMCAgICAgIDI4LjA4NTUwMDAwICAgICAgICAxCg==""",
         "xsf": """Q1JZU1RBTApQUklNVkVDCiAzLjg0NzM3MDAwMDAwMDAwIDAuMDAwMDAwMDAwMDAwMDAgMC4wMDAwMDAwMDAwMDAwMAogMS45MjM2ODUwMDAwMDAwMCAzLjMzMTkyMDAwMDAwMDAwIDAuMDAwMDAwMDAwMDAwMDAKIDEuOTIzNjg1MDAwMDAwMDAgMS4xMTA2NDAwMDAwMDAwMCAzLjE0MTM2NDAwMDAwMDAwClBSSU1DT09SRAogMiAxCiAxNCAgICAgMC4wMDAwMDAwMDAwMDAwMCAgICAgMC4wMDAwMDAwMDAwMDAwMCAgICAgMC4wMDAwMDAwMDAwMDAwMAogMTQgICAgIDEuOTIzNjg1MDAwMDAwMDAgICAgIDEuMTEwNjQwMDAwMDAwMDAgICAgIDAuNzg1MzQxMDAwMDAwMDAK""",
         "cif": """ZGF0YV9pbWFnZTAKX2NoZW1pY2FsX2Zvcm11bGFfc3RydWN0dXJhbCAgICAgICBTaTIKX2NoZW1pY2FsX2Zvcm11bGFfc3VtICAgICAgICAgICAgICAiU2kyIgpfY2VsbF9sZW5ndGhfYSAgICAgICAzLjg0NzM3Cl9jZWxsX2xlbmd0aF9iICAgICAgIDMuODQ3MzY5ODYzMzc3NDQ4Cl9jZWxsX2xlbmd0aF9jICAgICAgIDMuODQ3MzY5NjE2OTM1ODM2Cl9jZWxsX2FuZ2xlX2FscGhhICAgIDU5Ljk5OTk5NzA5Nzk3MDEyCl9jZWxsX2FuZ2xlX2JldGEgICAgIDU5Ljk5OTk5NjcwNjQwOTMwNgpfY2VsbF9hbmdsZV9nYW1tYSAgICA1OS45OTk5OTg4MjUzMTc1OQoKX3NwYWNlX2dyb3VwX25hbWVfSC1NX2FsdCAgICAiUCAxIgpfc3BhY2VfZ3JvdXBfSVRfbnVtYmVyICAgICAgIDEKCmxvb3BfCiAgX3NwYWNlX2dyb3VwX3N5bW9wX29wZXJhdGlvbl94eXoKICAneCwgeSwgeicKCmxvb3BfCiAgX2F0b21fc2l0ZV90eXBlX3N5bWJvbAogIF9hdG9tX3NpdGVfbGFiZWwKICBfYXRvbV9zaXRlX3N5bW1ldHJ5X211bHRpcGxpY2l0eQogIF9hdG9tX3NpdGVfZnJhY3RfeAogIF9hdG9tX3NpdGVfZnJhY3RfeQogIF9hdG9tX3NpdGVfZnJhY3RfegogIF9hdG9tX3NpdGVfb2NjdXBhbmN5CiAgU2kgIFNpMSAgICAgICAxLjAgIDAuMCAgMC4wICAwLjAgIDEuMDAwMAogIFNpICBTaTIgICAgICAgMS4wICAwLjI1MDAwMDAwMDAwMDAwMDA2ICAwLjI1ICAwLjI1ICAxLjAwMDAK""",
     }
@@ -281,10 +288,11 @@ def test_structure_data_viewer_selection(structure_data_object):
 def test_structure_data_viewer_representation(structure_data_object):
     v = viewers.viewer(structure_data_object)
 
-    # By default, there should be one "default" representation.
+    # There is always one representation, covering the whole structure.
     assert len(v._all_representations) == 1
     assert (
-        v._all_representations[0].style_id == "_aiidalab_viewer_representation_default"
+        viewers.parse_representation_style_id(v._all_representations[0].style_id)
+        is not None
     )
     assert v._all_representations[0].selection.value == "1..2"
 
@@ -308,16 +316,19 @@ def test_structure_data_viewer_representation(structure_data_object):
     v.structure = None
     v.structure = new_structure
 
-    # The new atom should appear in the default representation.
+    # The new atom should appear in the first representation.
     assert v._all_representations[0].selection.value == "1 3"
     assert "3" not in v.atoms_not_represented.value
 
-    # Delete the second representation.
-    assert v._all_representations[0].delete_button.layout.visibility == "hidden"
+    # Delete the second representation. With more than one around, either can go.
+    assert v._all_representations[0].delete_button.layout.visibility == "visible"
     assert v._all_representations[1].delete_button.layout.visibility == "visible"
     v._all_representations[1].delete_button.click()
     assert len(v._all_representations) == 1
     assert "2" in v.atoms_not_represented.value
+
+    # The last remaining representation cannot be deleted.
+    assert v._all_representations[0].delete_button.layout.visibility == "hidden"
 
     # Try to provide different object type than the viewer accepts.
     with pytest.raises(tl.TraitError):
@@ -397,7 +408,7 @@ def test_restore_representations_from_extras_warns_on_non_dict_extra():
         restored = viewer.restore_representations_from_extras(node, structure.copy())
 
     # Structure is returned unmodified, and the default array isn't set from extras.
-    assert viewers._DEFAULT_REPRESENTATION_STYLE_ID not in restored.arrays
+    assert UNSTYLED_STYLE_ID not in restored.arrays
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
@@ -409,14 +420,14 @@ def test_restore_representations_from_extras_warns_on_non_numeric_values():
     node = orm.StructureData(ase=structure)
     node.base.extras.set(
         viewers.VIEWER_REPRESENTATIONS_EXTRA,
-        {viewers._DEFAULT_REPRESENTATION_STYLE_ID: ["not", "numbers"]},
+        {UNSTYLED_STYLE_ID: ["not", "numbers"]},
     )
 
     viewer = viewers.StructureDataViewer()
     with pytest.warns(UserWarning, match="expected an array of integers"):
         restored = viewer.restore_representations_from_extras(node, structure.copy())
 
-    assert viewers._DEFAULT_REPRESENTATION_STYLE_ID not in restored.arrays
+    assert UNSTYLED_STYLE_ID not in restored.arrays
 
 
 @pytest.mark.usefixtures("aiida_profile_clean")
@@ -429,7 +440,7 @@ def test_restore_representations_from_extras_warns_on_length_mismatch():
     node.base.extras.set(
         viewers.VIEWER_REPRESENTATIONS_EXTRA,
         {
-            viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, 1, 1],  # 3 values, 2 atoms
+            UNSTYLED_STYLE_ID: [1, 1, 1],  # 3 values, 2 atoms
             "unrelated_key": "unrelated_value",  # not a representation array
         },
     )
@@ -439,7 +450,7 @@ def test_restore_representations_from_extras_warns_on_length_mismatch():
         restored = viewer.restore_representations_from_extras(node, structure.copy())
 
     # The mismatched array is ignored, and so is the unrelated, non-representation key.
-    assert viewers._DEFAULT_REPRESENTATION_STYLE_ID not in restored.arrays
+    assert UNSTYLED_STYLE_ID not in restored.arrays
     assert "unrelated_key" not in restored.arrays
 
 
@@ -452,14 +463,14 @@ def test_restore_representations_from_extras_noop_when_node_or_structure_is_none
     node = orm.StructureData(ase=structure).store()
     node.base.extras.set(
         viewers.VIEWER_REPRESENTATIONS_EXTRA,
-        {viewers._DEFAULT_REPRESENTATION_STYLE_ID: [1, 1]},
+        {UNSTYLED_STYLE_ID: [1, 1]},
     )
 
     viewer = viewers.StructureDataViewer()
 
     # node is None -> structure passed through untouched.
     result = viewer.restore_representations_from_extras(None, structure.copy())
-    assert viewers._DEFAULT_REPRESENTATION_STYLE_ID not in result.arrays
+    assert UNSTYLED_STYLE_ID not in result.arrays
 
     # structure is None -> returned untouched (i.e. still None).
     assert viewer.restore_representations_from_extras(node, None) is None
@@ -504,9 +515,10 @@ def test_structure_data_viewer_drops_stale_representations_on_structure_change()
         positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1), (0.0, 1.0, 0.0)],
     )
 
-    assert [rep.style_id for rep in viewer._all_representations] == [
-        viewers.StructureDataViewer.DEFAULT_REPRESENTATION
-    ]
+    # A structure carrying no representation array is seeded with one covering
+    # every atom, keeping the style the viewer is currently set to.
+    assert len(viewer._all_representations) == 1
+    assert viewer._all_representations[0].style_id == style_id
     assert viewer._all_representations[0].selection.value == "1..3"
 
 
@@ -832,3 +844,45 @@ def test_node_view_caching():
     node_view.node = node
     assert node_view.children[0] is viewer
     assert len(node_view.node_views) == 1
+
+
+def test_structure_data_viewer_assigns_appended_atom_to_first_representation():
+    """An atom appended to a structure belongs to exactly one representation.
+
+    ASE pads the representation arrays of a grown structure with the unassigned
+    marker. Such an atom must not be picked up by every representation at once,
+    nor dropped by all of them.
+    """
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    viewer._all_representations[0].selection.value = "1"
+    viewer._apply_representations()
+    viewer._add_representation(indices=[1])
+    assert [rep.selection.value for rep in viewer._all_representations] == ["1", "2"]
+
+    grown = viewer.structure.copy()
+    grown.append(ase.Atom("C", (0.5, 0.5, 0.5)))
+    viewer.structure = grown
+
+    assert [rep.selection.value for rep in viewer._all_representations] == ["1 3", "2"]
+    assert viewer.atoms_not_represented.value == ""
+
+
+def test_structure_data_viewer_keeps_atoms_excluded_from_every_representation():
+    """Claiming unassigned atoms must not resurrect deliberately hidden ones."""
+    viewer = viewers.StructureDataViewer()
+    viewer.structure = ase.Atoms(
+        symbols=["C", "H"],
+        positions=[(0.0, 0.0, 0.0), (0.0, 0.0, 1.1)],
+    )
+    viewer._all_representations[0].selection.value = "1"
+    viewer._apply_representations()
+
+    # Re-entering the validator must leave the excluded atom excluded.
+    viewer.structure = viewer.structure.copy()
+
+    assert viewer._all_representations[0].selection.value == "1"
+    assert "2" in viewer.atoms_not_represented.value


### PR DESCRIPTION
Its fixed array name `_aiidalab_viewer_representation_default` doesn't encode the style from #768, so its type, size and color reset on reload. The name earned nothing else: "always present, cannot be deleted" belongs to the list, not to one member.

- Every representation gets an encoded style id. Removes `DEFAULT_REPRESENTATION` and `_sync_style_id_with_settings`; an unstyled name is renamed on the next apply.
- The delete button is hidden only on the last representation, so `deletable` is gone.
- Replaces `atom_show_threshold` with an `_AtomMarker` enum: `IN` (1), `OUT` (-1), `UNASSIGNED` (0). Membership is uniformly `== IN`.
- Unassigned always go to the first representation, so a new atom is displayed exactly once.
- An array is seeded only when the structure carries none.