### PR TITLE
Ignore generated numbered notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ target/
 .ipynb_checkpoints
 .*.ipynb
 
+# Numbered copies created when AiiDAlab reopens running notebooks
+*-[0-9]*.ipynb
+
 # pyenv
 .python-version
 


### PR DESCRIPTION
## Summary

Ignore numbered notebook copies such as `search-0.ipynb` and `search-12.ipynb` that AiiDAlab can create when reopening a running notebook.

Canonical notebooks remain tracked. The rule only prevents generated copies with a numeric suffix from being added accidentally.

## Validation

- Confirmed that the change only modifies `.gitignore`.
- `git diff --check` passes.

Prepared with Codex assistance.