### PR TITLE
Preserve ELN provenance through structure edits

### DIFF
--- a/aiidalab_widgets_base/structures.py
+++ b/aiidalab_widgets_base/structures.py
@@ -1,5 +1,6 @@
 """Module to provide functionality to import structures."""
 
+import copy
 import datetime
 import functools
 import io
@@ -36,6 +37,7 @@ SYMBOL_RADIUS = {
 }
 
 ASE_IO_URL = "https://ase.gitlab.io/ase/ase/io/io.html#ase.io.write"
+ELN_ORIGIN_EXTRA = "eln"
 
 
 class StructureManagerWidget(ipw.VBox):
@@ -306,6 +308,11 @@ class StructureManagerWidget(ipw.VBox):
             structure_node = structure_node_type(ase=structure)
             if "smiles" in structure.info:
                 structure_node.base.extras.set("smiles", structure.info["smiles"])
+            origin = structure.info.get(ELN_ORIGIN_EXTRA)
+            if origin is None and isinstance(self.input_structure, orm.Data):
+                origin = self.input_structure.base.extras.get(ELN_ORIGIN_EXTRA, None)
+            if origin is not None:
+                structure_node.base.extras.set(ELN_ORIGIN_EXTRA, copy.deepcopy(origin))
             return structure_node
 
         # If the input_structure trait is set to AiiDA node, check what type
@@ -358,12 +365,19 @@ class StructureManagerWidget(ipw.VBox):
         ):  # Special treatement of the CifData object
             str_io = io.StringIO(change["new"].get_content())
             structure = ase.io.read(str_io, format="cif", reader="ase", store_tags=True)
+            origin = change["new"].base.extras.get(ELN_ORIGIN_EXTRA, None)
+            if origin is not None:
+                structure.info[ELN_ORIGIN_EXTRA] = copy.deepcopy(origin)
             self.structure = self.viewer.restore_representations_from_extras(
                 change["new"], structure
             )
         elif isinstance(change["new"], StructureData):
+            structure = change["new"].get_ase()
+            origin = change["new"].base.extras.get(ELN_ORIGIN_EXTRA, None)
+            if origin is not None:
+                structure.info[ELN_ORIGIN_EXTRA] = copy.deepcopy(origin)
             self.structure = self.viewer.restore_representations_from_extras(
-                change["new"], change["new"].get_ase()
+                change["new"], structure
             )
 
         else:

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -848,3 +848,51 @@ def test_basic_structure_editor(structure_data_object):
     widget.add()
     assert len(widget.structure) == 7
     assert widget.structure.get_chemical_formula() == "C2H3OSi"
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_preserves_eln_origin_through_edits():
+    origin = {
+        "eln_instance": "https://openbis.example",
+        "eln_type": "openbis",
+        "sample_uuid": "20260912123456789-1234",
+        "data_type": "MOLECULE",
+        "representation": "smiles",
+        "structure_fingerprint": "original-fingerprint",
+    }
+    source = orm.StructureData(
+        ase=ase.Atoms("CH4", cell=[10, 10, 10], pbc=False)
+    ).store()
+    source.base.extras.set("eln", origin)
+
+    widget = awb.StructureManagerWidget(
+        importers=[], input_structure=source, node_class="StructureData"
+    )
+    assert widget.structure.info["eln"] == origin
+
+    edited = widget.structure.copy()
+    edited.positions[0, 0] += 0.25
+    widget.structure = edited
+
+    assert widget.structure_node.base.extras.get("eln") == origin
+    widget.btn_store.click()
+    assert widget.structure_node.is_stored
+    assert widget.structure_node.base.extras.get("eln") == origin
+    assert source.base.extras.get("eln") == origin
+
+
+@pytest.mark.usefixtures("aiida_profile_clean")
+def test_structure_manager_copies_eln_origin_from_ase_input():
+    origin = {
+        "eln_instance": "https://openbis.example",
+        "sample_uuid": "20260912123456789-1234",
+        "data_type": "ATOMISTIC_MODEL",
+    }
+    structure = ase.Atoms("Au", cell=[5, 5, 5], pbc=True)
+    structure.info["eln"] = origin
+
+    widget = awb.StructureManagerWidget(
+        importers=[], input_structure=structure, node_class="StructureData"
+    )
+
+    assert widget.structure_node.base.extras.get("eln") == origin


### PR DESCRIPTION
## Summary
- copy the standard eln origin extra into ASE structure metadata
- preserve it when StructureManagerWidget creates a modified StructureData
- leave the original stored input node untouched

This is the small shared provenance layer required by the openBIS structure importer.

## Validation
- all 39 StructureManager tests pass
- formatting and ruff checks pass
- the repository-wide ty hook is blocked in this environment by pre-existing missing optional dependencies